### PR TITLE
NullReferenceException during mapping fixed : fixes #42

### DIFF
--- a/DEHEASysML.Tests/MappingRules/ElementDefinitionToBlockMappingRuleTestFixture.cs
+++ b/DEHEASysML.Tests/MappingRules/ElementDefinitionToBlockMappingRuleTestFixture.cs
@@ -62,6 +62,7 @@ namespace DEHEASysML.Tests.MappingRules
         private Mock<IMappingConfigurationService> mappingConfiguration;
         private Dictionary<string, string> updatedValuePropretyValues;
         private Dictionary<Element, List<(Partition, ChangeKind)>> modifiedPartitions;
+        private Dictionary<string, int> updatedPropertyTypes;
         private List<Connector> createrConnectors;
 
         [SetUp]
@@ -70,6 +71,7 @@ namespace DEHEASysML.Tests.MappingRules
             var defaultPackage = new Mock<Package>();
             defaultPackage.Setup(x => x.Elements).Returns(new EnterpriseArchitectCollection());
 
+            this.updatedPropertyTypes = new Dictionary<string, int>();
             this.createrConnectors = new List<Connector>();
             this.modifiedPartitions = new Dictionary<Element, List<(Partition, ChangeKind)>>();
             this.updatedValuePropretyValues = new Dictionary<string, string>();
@@ -79,6 +81,7 @@ namespace DEHEASysML.Tests.MappingRules
             this.dstController.Setup(x => x.GetDefaultPackage(It.IsAny<StereotypeKind>())).Returns(defaultPackage.Object);
             this.dstController.Setup(x => x.ModifiedPartitions).Returns(this.modifiedPartitions);
             this.dstController.Setup(x => x.CreatedConnectors).Returns(this.createrConnectors);
+            this.dstController.Setup(x => x.UpdatePropertyTypes).Returns(this.updatedPropertyTypes);
             this.mappingConfiguration = new Mock<IMappingConfigurationService>();
 
             var containerBuilder = new ContainerBuilder();

--- a/DEHEASysML/DstController/IDstController.cs
+++ b/DEHEASysML/DstController/IDstController.cs
@@ -126,6 +126,11 @@ namespace DEHEASysML.DstController
         List<Connector> CreatedConnectors { get; }
 
         /// <summary>
+        /// Corrspondance between a <see cref="Element"/> Guid of Stereotype ValueProperty and new PropertyType Value
+        /// </summary>
+        Dictionary<string, int> UpdatePropertyTypes { get; }
+
+        /// <summary>
         /// Handle to clear everything when Enterprise Architect close
         /// </summary>
         void Disconnect();
@@ -326,5 +331,13 @@ namespace DEHEASysML.DstController
         /// <param name="elementRequirement">The retrieved <see cref="Element" /></param>
         /// <returns>A value indicating if the <see cref="Element" /> has been found</returns>
         bool TryGetRequirement(string name, string id, out Element elementRequirement);
+
+        /// <summary>
+        /// Tries to get the block that define the correct given Interface
+        /// </summary>
+        /// <param name="interfaceElement">The <see cref="Element"/></param>
+        /// <param name="blockDefinition">The retrieve block <see cref="Element"/></param>
+        /// <returns>a value indicating if the <see cref="Element"/> has been found</returns>
+        bool TryGetInterfaceImplementation(Element interfaceElement, out Element blockDefinition);
     }
 }

--- a/DEHEASysML/MappingRules/BlockDefinitionToElementDefinitionMappingRule.cs
+++ b/DEHEASysML/MappingRules/BlockDefinitionToElementDefinitionMappingRule.cs
@@ -207,13 +207,18 @@ namespace DEHEASysML.MappingRules
 
                 var elementUsageName = $"{interfaceBlock.Name}_Impl";
 
+                if (this.DstController.TryGetInterfaceImplementation(interfaceBlock, out var blockDefinition))
+                {
+                    elementUsageName = blockDefinition.Name;
+                }
+
                 var interfaceElementUsage = this.portsToConnect
                     .FirstOrDefault(x => x.Item1.PropertyTypeName as string == elementUsageName).Item3;
 
                 if (interfaceElementUsage == null)
                 {
                     interfaceElementUsage = this.HubController.OpenIteration.Element.SelectMany(x => x.ContainedElement)
-                        .FirstOrDefault(x => x.Name == elementUsageName);
+                        .FirstOrDefault(x => x.Name == elementUsageName)?.Clone(false);
 
                     if (interfaceElementUsage == null)
                     {
@@ -683,7 +688,7 @@ namespace DEHEASysML.MappingRules
         /// <param name="partProperty">The PartProperty</param>
         private void MapPartProperty(ElementDefinition container, Element partProperty)
         {
-            if (container == null)
+            if (container == null || partProperty.PropertyType == 0)
             {
                 return;
             }
@@ -695,9 +700,8 @@ namespace DEHEASysML.MappingRules
             {
                 mappedElement = new EnterpriseArchitectBlockElement(this.GetOrCreateElementDefinition(partPropertyBlock), partPropertyBlock, MappingDirection.FromDstToHub);
                 this.Elements.Add(mappedElement);
+                this.MapElement(mappedElement);
             }
-
-            this.MapElement(mappedElement);
 
             if (container.ContainedElement.Any(x => x.ElementDefinition.Iid == mappedElement.HubElement.Iid))
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEH-EASYSML/pulls) open
- [x] I have verified that I am following the DEH-EASYSML [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEH-EASYSML/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #42 

Bug fixed, if a ValueType where already existing but without unit linked, it tries to compare the name of a null unit with another name. 
Fixes also the fact that at some times, a relationship could not be done between a Port and an Interface if the name of the Interface did not match with the correct pattern ("$(InterfaceName)_Impl"). 
<!-- Thanks for contributing to DEH-EASYSML! -->