### PR TITLE
Fix parameters transfer and dstNetChange performance : Fixes #40, #44

### DIFF
--- a/DEHEASysML.Tests/Services/Dispatcher/DispatcherTestFixture.cs
+++ b/DEHEASysML.Tests/Services/Dispatcher/DispatcherTestFixture.cs
@@ -29,6 +29,8 @@ namespace DEHEASysML.Tests.Services.Dispatcher
 
     using Autofac;
 
+    using CDP4Common;
+
     using DEHEASysML.DstController;
     using DEHEASysML.Services.Dispatcher;
     using DEHEASysML.ViewModel;
@@ -68,7 +70,9 @@ namespace DEHEASysML.Tests.Services.Dispatcher
             this.dstController.Setup(x => x.OnFileNew(this.repository.Object));
             this.dstController.Setup(x => x.OnFileOpen(this.repository.Object));
             this.dstController.Setup(x => x.OnNotifyContextItemModified(this.repository.Object, It.IsAny<string>(),It.IsAny<ObjectType>()));
-
+            this.dstController.Setup(x => x.OnContextItemChanged(this.repository.Object, It.IsAny<string>(),It.IsAny<ObjectType>()));
+            this.dstController.Setup(x => x.OnPackageEvent(It.IsAny<Repository>(), It.IsAny<ChangeKind>(), It.IsAny<int>()));
+            this.dstController.Setup(x => x.OnElementEvent(It.IsAny<Repository>(), It.IsAny<ChangeKind>(), It.IsAny<int>()));
             this.dstController.Setup(x => x.RetrieveAllParentsIdPackage(It.IsAny<IEnumerable<Element>>()))
                 .Returns(new List<int>());
 
@@ -150,6 +154,11 @@ namespace DEHEASysML.Tests.Services.Dispatcher
             Assert.DoesNotThrow(() => this.dispatcher.OnFileClose(this.repository.Object));
             Assert.DoesNotThrow(() => this.dispatcher.OnFileOpen(this.repository.Object));
             Assert.DoesNotThrow(() => this.dispatcher.OnNotifyContextItemModified(this.repository.Object, Guid.NewGuid().ToString(), ObjectType.otDiagram));
+            Assert.DoesNotThrow(() => this.dispatcher.OnContextItemChanged(this.repository.Object, Guid.NewGuid().ToString(), ObjectType.otDiagram));
+            Assert.DoesNotThrow(() => this.dispatcher.OnNewElement(this.repository.Object, 45));
+            Assert.DoesNotThrow(() => this.dispatcher.OnDeleteElement(this.repository.Object, 45));
+            Assert.DoesNotThrow(() => this.dispatcher.OnNewPackage(this.repository.Object, 45));
+            Assert.DoesNotThrow(() => this.dispatcher.OnDeletePackage(this.repository.Object, 45));
 
             this.dstController.Verify(x => x.OnFileNew(this.repository.Object), Times.Once);
             this.dstController.Verify(x => x.OnFileClose(this.repository.Object), Times.Once);

--- a/DEHEASysML.Tests/Utils/Stereotypes/EnterpriseArchitectCollection.cs
+++ b/DEHEASysML.Tests/Utils/Stereotypes/EnterpriseArchitectCollection.cs
@@ -125,7 +125,17 @@ namespace DEHEASysML.Tests.Utils.Stereotypes
         /// <returns>The created object</returns>
         public object AddNew(string Name, string Type)
         {
-            return Type.AreEquals(StereotypeKind.Dependency) ? new Mock<Connector>().Object : null;
+            if (Type.AreEquals(StereotypeKind.Dependency))
+            {
+                return new Mock<Connector>().Object;
+            }
+
+            if (Type.AreEquals(StereotypeKind.Package))
+            {
+                return new Mock<Package>().Object;
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/DEHEASysML.Tests/ViewModel/NetChangePreview/HubObjectNetChangePreviewViewModelTestFixture.cs
+++ b/DEHEASysML.Tests/ViewModel/NetChangePreview/HubObjectNetChangePreviewViewModelTestFixture.cs
@@ -207,7 +207,15 @@ namespace DEHEASysML.Tests.ViewModel.NetChangePreview
                 Group = parameterGroup
             };
 
+            var elementUsage = new ElementUsage()
+            {
+                Iid = Guid.NewGuid(),
+                Container = elementDefinition,
+                ElementDefinition = new ElementDefinition()
+            };
+
             elementDefinition.Parameter.Add(parameter);
+            elementDefinition.ContainedElement.Add(elementUsage);
 
             var elementDefinition2 = new ElementDefinition()
             {
@@ -221,7 +229,7 @@ namespace DEHEASysML.Tests.ViewModel.NetChangePreview
             this.viewModel.ComputeValues();
 
             Assert.DoesNotThrow(() => this.viewModel.SelectAllCommand.Execute(null));
-            Assert.AreEqual(1, this.selectedDstMapResultForTransfer.Count);
+            Assert.AreEqual(2, this.selectedDstMapResultForTransfer.Count);
 
             Assert.DoesNotThrow(() => this.viewModel.DeselectAllCommand.Execute(null));
             Assert.AreEqual(0, this.selectedDstMapResultForTransfer.Count);
@@ -233,15 +241,19 @@ namespace DEHEASysML.Tests.ViewModel.NetChangePreview
             this.viewModel.GetElementDefinitionRowViewModel(elementDefinition2, out var elementDefinitionRow2);
             Assert.DoesNotThrow(() => this.viewModel.SelectedThings.Add(elementDefinitionRow));
             Assert.DoesNotThrow(() => this.viewModel.SelectedThings.Add(elementDefinitionRow2));
-            Assert.AreEqual(1, this.selectedDstMapResultForTransfer.Count);
+            Assert.AreEqual(2, this.selectedDstMapResultForTransfer.Count);
 
             var parameterGroupRow = elementDefinitionRow.ContainedRows.OfType<ParameterGroupRowViewModel>().First();
             Assert.DoesNotThrow(() => this.viewModel.SelectedThings.Add(parameterGroupRow));
-            Assert.AreEqual(0, this.selectedDstMapResultForTransfer.Count);
+            Assert.AreEqual(2, this.selectedDstMapResultForTransfer.Count);
 
-            var parameterRow = parameterGroupRow.ContainedRows.OfType<ParameterOrOverrideBaseRowViewModel>().First();
+            var parameterRow = parameterGroupRow.ContainedRows.OfType<ParameterRowViewModel>().First();
             Assert.DoesNotThrow(() => this.viewModel.SelectedThings.Add(parameterRow));
             Assert.AreEqual(1, this.selectedDstMapResultForTransfer.Count);
+
+            var elementUsageRow = elementDefinitionRow.ContainedRows.OfType<ElementUsageRowViewModel>().First();
+            Assert.DoesNotThrow(() => this.viewModel.SelectedThings.Add(elementUsageRow));
+            Assert.AreEqual(0, this.selectedDstMapResultForTransfer.Count);
         }
     }
 }

--- a/DEHEASysML/App.cs
+++ b/DEHEASysML/App.cs
@@ -313,6 +313,70 @@ namespace DEHEASysML
         }
 
         /// <summary>
+        /// This event occurs when a user drags a new Package from the Toolbox or Resources window onto a diagram,
+        /// or by selecting the New Package icon from the Project Browser.
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository" /></param>
+        /// <param name="info">The <see cref="EventProperties"/></param>
+        public bool EA_OnPostNewPackage(Repository repository, EventProperties info)
+        {
+            for(short propertiesIndex = 0; propertiesIndex < info.Count; propertiesIndex++)
+            {
+                this.dispatcher.OnNewPackage(repository, int.Parse((string)info.Get(propertiesIndex).Value));
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// This event occurs after a user has dragged a new element from the Toolbox or Resources window onto a diagram.
+        /// The notification is provided immediately after the element is added to the model. 
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository" /></param>
+        /// <param name="info">The <see cref="EventProperties"/></param>
+        public bool EA_OnPostNewElement(Repository repository, EventProperties info)
+        {
+            for (short propertiesIndex = 0; propertiesIndex < info.Count; propertiesIndex++)
+            {
+                this.dispatcher.OnNewElement(repository, int.Parse((string)info.Get(propertiesIndex).Value));
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// This event occurs when a user deletes an element from the Project Browser or on a diagram.
+        /// The notification is provided immediately before the element is deleted, so that the Add-In can disable deletion of the element.
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository" /></param>
+        /// <param name="info">The <see cref="EventProperties"/></param>
+        public bool EA_OnPreDeleteElement(Repository repository, EventProperties info)
+        {
+            for (short propertiesIndex = 0; propertiesIndex < info.Count; propertiesIndex++)
+            {
+                this.dispatcher.OnDeleteElement(repository, int.Parse((string)info.Get(propertiesIndex).Value));
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// This event occurs when a user attempts to permanently delete a Package from the Project Browser.
+        /// The notification is provided immediately before the Package is deleted, so that the Add-In can disable deletion of the Package.
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository" /></param>
+        /// <param name="info">The <see cref="EventProperties"/></param>
+        public bool EA_OnPreDeletePackage(Repository repository, EventProperties info)
+        {
+            for (short propertiesIndex = 0; propertiesIndex < info.Count; propertiesIndex++)
+            {
+                this.dispatcher.OnDeletePackage(repository, int.Parse((string)info.Get(propertiesIndex).Value));
+            }
+
+            return true;
+        }
+
+        /// <summary>
         /// This event occurs when a user has modified the context item. Add-Ins that require knowledge of when an item has been
         /// modified can subscribe to this broadcast function.
         /// </summary>
@@ -325,6 +389,19 @@ namespace DEHEASysML
         }
 
         /// <summary>
+        /// This event occurs after a user has selected an item anywhere in the Enterprise Architect GUI.
+        /// Add-Ins that require knowledge of the current item in context can subscribe to this broadcast function.
+        /// If ot = otRepository, then this function behaves in the same way as EA_FileOpen.
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository"/></param>
+        /// <param name="guid">Contains the GUID of the new context item</param>
+        /// <param name="objectType">The <see cref="ObjectType"/></param>
+        public void EA_OnContextItemChanged(Repository repository, string guid, ObjectType objectType)
+        {
+            this.dispatcher.OnContextItemChanged(repository, guid, objectType);
+        }
+
+            /// <summary>
         /// Asserts that a project is opened
         /// </summary>
         /// <param name="repository">The <see cref="Repository" /></param>

--- a/DEHEASysML/DEHEASysML.csproj
+++ b/DEHEASysML/DEHEASysML.csproj
@@ -23,7 +23,7 @@
     <None Remove="Resources\icon.ico" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DEHPCommon" Version="1.0.254" />
+    <PackageReference Include="DEHPCommon" Version="1.0.263" />
     <PackageReference Include="NLog" Version="4.6.8" />
     <PackageReference Include="reactiveui" Version="6.5.0" />
     <PackageReference Include="Rx-Linq" Version="2.2.5" />
@@ -48,10 +48,6 @@
     <Resource Include="Resources\icon.ico">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Resource>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Events\" />
-    <Folder Include="Extensions\" />
   </ItemGroup>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Target Name="AfterBuild">

--- a/DEHEASysML/DstController/IDstController.cs
+++ b/DEHEASysML/DstController/IDstController.cs
@@ -126,7 +126,7 @@ namespace DEHEASysML.DstController
         List<Connector> CreatedConnectors { get; }
 
         /// <summary>
-        /// Corrspondance between a <see cref="Element"/> Guid of Stereotype ValueProperty and new PropertyType Value
+        /// Correspondance between a <see cref="Element"/> Guid of Stereotype ValueProperty and new PropertyType Value
         /// </summary>
         Dictionary<string, int> UpdatePropertyTypes { get; }
 
@@ -339,5 +339,36 @@ namespace DEHEASysML.DstController
         /// <param name="blockDefinition">The retrieve block <see cref="Element"/></param>
         /// <returns>a value indicating if the <see cref="Element"/> has been found</returns>
         bool TryGetInterfaceImplementation(Element interfaceElement, out Element blockDefinition);
+
+        /// <summary>
+        /// Handle the execution of the EA_OnPostNewPackage or EA_OnPreDeletePackage event
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository"/></param>
+        /// <param name="changeKind">The <see cref="ChangeKind"/></param>
+        /// <param name="value">The id of <see cref="Package"/></param>
+        void OnPackageEvent(Repository repository, ChangeKind changeKind,int value);
+
+        /// <summary>
+        /// Handle the execution of the EA_OnPostNewElement or EA_OnPreDeleteElement event
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository"/></param>
+        /// <param name="changeKind">The <see cref="ChangeKind"/></param>
+        /// <param name="value">The id of <see cref="Element"/></param>
+        void OnElementEvent(Repository repository, ChangeKind changeKind, int value);
+
+        /// <summary>
+        /// Gets the Id of each parent of the given <see cref="Package" /> Id
+        /// </summary>
+        /// <param name="packageId">The <see cref="Package" /> id</param>
+        /// <param name="packagesId">A collection of all <see cref="Package" /> already found</param>
+        void GetPackageParentId(int packageId, ref List<int> packagesId);
+
+        /// <summary>
+        /// Handle the OnNotifyContextItemModified event from EA
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository" /></param>
+        /// <param name="guid">The guid of the Item</param>
+        /// <param name="objectType">The <see cref="ObjectType" /> of the item</param>
+        void OnContextItemChanged(Repository repository, string guid, ObjectType objectType);
     }
 }

--- a/DEHEASysML/Enumerators/StereotypeKind.cs
+++ b/DEHEASysML/Enumerators/StereotypeKind.cs
@@ -107,6 +107,16 @@ namespace DEHEASysML.Enumerators
         /// <summary>
         /// Used to represent the Partition MetaType
         /// </summary>
-        Partition
+        Partition,
+
+        /// <summary>
+        /// Used to represent the Package MetaType
+        /// </summary>
+        Package,
+
+        /// <summary>
+        /// Used to represent the Realization MetaType
+        /// </summary>
+        Realization
     }
 }

--- a/DEHEASysML/Events/EnterpriseArchitectElementEvent.cs
+++ b/DEHEASysML/Events/EnterpriseArchitectElementEvent.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ElementRowViewModel.cs" company="RHEA System S.A.">
+// <copyright file="EnterpriseArchitectElementPackage.cs" company="RHEA System S.A.">
 // Copyright (c) 2020-2022 RHEA System S.A.
 // 
 // Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate.
@@ -22,43 +22,24 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows
+namespace DEHEASysML.Events
 {
-    using EA;
+    using CDP4Common;
+
+    using CDP4Dal;
 
     /// <summary>
-    /// The <see cref="ElementRowViewModel" /> represents a row for an <see cref="Element" />
+    /// An event for the <see cref="CDPMessageBus"/>
     /// </summary>
-    public abstract class ElementRowViewModel : EnterpriseArchitectObjectRowViewModel<Element>
+    public class EnterpriseArchitectElementEvent : EnterpriseArchitectEvent
     {
         /// <summary>
-        /// Initializes a new <see cref="ElementRowViewModel" />
+        /// Initializes a new instance of the <see cref="EnterpriseArchitectElementEvent" /> class.
         /// </summary>
-        /// <param name="parent">The parent row</param>
-        /// <param name="eaObject">The object to represent</param>
-        protected ElementRowViewModel(EnterpriseArchitectObjectBaseRowViewModel parent, Element eaObject)
-            : base(parent, eaObject)
+        /// <param name="changeKind">The <see cref="ChangeKind"/></param>
+        /// <param name="id">The id</param>
+        public EnterpriseArchitectElementEvent(ChangeKind changeKind, int id) : base(changeKind, id)
         {
-        }
-
-        /// <summary>
-        /// Update the current <see cref="Element" />
-        /// </summary>
-        /// <param name="element">The new <see cref="Element" /></param>
-        public void UpdateElement(Element element)
-        {
-            this.ContainedRows.Clear();
-            this.RepresentedObject = element;
-            this.UpdateProperties();
-        }
-
-        /// <summary>
-        /// Updates this view model properties;
-        /// </summary>
-        protected override void UpdateProperties()
-        {
-            base.UpdateProperties();
-            this.ComputeRow();
         }
     }
 }

--- a/DEHEASysML/Events/EnterpriseArchitectEvent.cs
+++ b/DEHEASysML/Events/EnterpriseArchitectEvent.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="StateRowViewModel.cs" company="RHEA System S.A.">
+// <copyright file="EnterpriseArchitectEvent.cs" company="RHEA System S.A.">
 // Copyright (c) 2020-2022 RHEA System S.A.
 // 
 // Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate.
@@ -22,50 +22,38 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows
+namespace DEHEASysML.Events
 {
-    using System.Linq;
+    using CDP4Common;
 
-    using DEHEASysML.Enumerators;
+    using CDP4Dal;
 
     using EA;
 
     /// <summary>
-    /// The <see cref="StateRowViewModel" /> represents an <see cref="Element" /> of Type State
+    /// An event for the <see cref="CDPMessageBus"/>
     /// </summary>
-    public class StateRowViewModel : ElementRowViewModel
+    public abstract class EnterpriseArchitectEvent
     {
         /// <summary>
-        /// Initializes a new <see cref="StateRowViewModel" />
+        /// The <see cref="ChangeKind" /> of the Event
         /// </summary>
-        /// <param name="parent">The parent row</param>
-        /// <param name="eaObject">The object to represent</param>
-        public StateRowViewModel(EnterpriseArchitectObjectBaseRowViewModel parent, Element eaObject) : base(parent, eaObject)
-        {
-            this.Initialize();
-        }
+        public ChangeKind ChangeKind { get; }
 
         /// <summary>
-        /// Compute the current row to initializes properties
+        /// The Id of the related <see cref="Element"/> or <see cref="Package"/>
         /// </summary>
-        public override void ComputeRow()
-        {
-            this.ContainedRows.Clear();
-
-            this.RowType = StereotypeKind.State.ToString();
-
-            foreach (var partition in this.RepresentedObject.Partitions.OfType<Partition>())
-            {
-                this.ContainedRows.Add(new PartitionRowViewModel(this, partition));
-            }
-        }
+        public int Id { get; }
 
         /// <summary>
-        /// Initializes this row properties
+        /// Initializes a new instance of the <see cref="EnterpriseArchitectEvent" /> class.
         /// </summary>
-        private void Initialize()
+        /// <param name="changeKind">The <see cref="ChangeKind"/></param>
+        /// <param name="id">The id</param>
+        protected EnterpriseArchitectEvent(ChangeKind changeKind, int id)
         {
-            this.UpdateProperties();
+            this.ChangeKind = changeKind;
+            this.Id = id;
         }
     }
 }

--- a/DEHEASysML/Events/EnterpriseArchitectPackageEvent.cs
+++ b/DEHEASysML/Events/EnterpriseArchitectPackageEvent.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ElementRowViewModel.cs" company="RHEA System S.A.">
+// <copyright file="EnterpriseArchitectPackageEvent.cs" company="RHEA System S.A.">
 // Copyright (c) 2020-2022 RHEA System S.A.
 // 
 // Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate.
@@ -22,43 +22,24 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows
+namespace DEHEASysML.Events
 {
-    using EA;
+    using CDP4Common;
+
+    using CDP4Dal;
 
     /// <summary>
-    /// The <see cref="ElementRowViewModel" /> represents a row for an <see cref="Element" />
+    /// An event for the <see cref="CDPMessageBus"/>
     /// </summary>
-    public abstract class ElementRowViewModel : EnterpriseArchitectObjectRowViewModel<Element>
+    public class EnterpriseArchitectPackageEvent : EnterpriseArchitectEvent
     {
         /// <summary>
-        /// Initializes a new <see cref="ElementRowViewModel" />
+        /// Initializes a new instance of the <see cref="EnterpriseArchitectPackageEvent" /> class.
         /// </summary>
-        /// <param name="parent">The parent row</param>
-        /// <param name="eaObject">The object to represent</param>
-        protected ElementRowViewModel(EnterpriseArchitectObjectBaseRowViewModel parent, Element eaObject)
-            : base(parent, eaObject)
+        /// <param name="changeKind">The <see cref="ChangeKind"/></param>
+        /// <param name="id">The id</param>
+        public EnterpriseArchitectPackageEvent(ChangeKind changeKind, int id) : base(changeKind, id)
         {
-        }
-
-        /// <summary>
-        /// Update the current <see cref="Element" />
-        /// </summary>
-        /// <param name="element">The new <see cref="Element" /></param>
-        public void UpdateElement(Element element)
-        {
-            this.ContainedRows.Clear();
-            this.RepresentedObject = element;
-            this.UpdateProperties();
-        }
-
-        /// <summary>
-        /// Updates this view model properties;
-        /// </summary>
-        protected override void UpdateProperties()
-        {
-            base.UpdateProperties();
-            this.ComputeRow();
         }
     }
 }

--- a/DEHEASysML/Extensions/StereotypeExtensions.cs
+++ b/DEHEASysML/Extensions/StereotypeExtensions.cs
@@ -277,7 +277,7 @@ namespace DEHEASysML.Extensions
                 case StereotypeKind.Unit:
                     return "SysML1.3::unit";
                 case StereotypeKind.Block:
-                    return "SysML1.3::block";
+                    return "SysML1.4::block";
                 case StereotypeKind.Requirement:
                     return "SysML1.4::requirement";
                 case StereotypeKind.Port:

--- a/DEHEASysML/MappingRules/ElementDefinitionToBlockMappingRule.cs
+++ b/DEHEASysML/MappingRules/ElementDefinitionToBlockMappingRule.cs
@@ -160,10 +160,8 @@ namespace DEHEASysML.MappingRules
 
                 var interfaceElement = this.GetOrCreateInterface(relationsShip.Name);
 
-                if (targetType == StereotypeKind.RequiredInterface)
-                {
-                    this.CreateOrUpdateConnector(portDefinition, interfaceElement);
-                }
+                this.CreateOrUpdateConnector(portDefinition, interfaceElement
+                    , targetType == StereotypeKind.RequiredInterface ? StereotypeKind.Usage : StereotypeKind.Realization);
 
                 var embeddedInterface = port.EmbeddedElements.OfType<Element>().FirstOrDefault(x => x.MetaType.AreEquals(targetType))
                                         ?? this.DstController.AddNewElement(port.Elements, interfaceElement.Name, targetType.ToString(), targetType);
@@ -179,13 +177,14 @@ namespace DEHEASysML.MappingRules
         /// </summary>
         /// <param name="portDefinition">The port <see cref="Element" /> definition</param>
         /// <param name="interfaceElement">The interface <see cref="Element" /></param>
-        private void CreateOrUpdateConnector(Element portDefinition, Element interfaceElement)
+        /// <param name="connectorType">The type of the connector</param>
+        private void CreateOrUpdateConnector(Element portDefinition, Element interfaceElement, StereotypeKind connectorType)
         {
             var connector = portDefinition.GetAllConnectorsOfElement().FirstOrDefault();
 
             if (connector == null)
             {
-                connector = portDefinition.Connectors.AddNew("", StereotypeKind.Usage.ToString()) as Connector;
+                connector = portDefinition.Connectors.AddNew("", connectorType.ToString()) as Connector;
                 this.DstController.CreatedConnectors.Add(connector);
             }
 
@@ -309,6 +308,8 @@ namespace DEHEASysML.MappingRules
                 this.VerifyStateDependency(parameter, property);
                 this.UpdateValue(parameter, property);
             }
+
+            element.Update();
         }
 
         /// <summary>

--- a/DEHEASysML/Services/Dispatcher/Dispatcher.cs
+++ b/DEHEASysML/Services/Dispatcher/Dispatcher.cs
@@ -30,6 +30,8 @@ namespace DEHEASysML.Services.Dispatcher
 
     using Autofac;
 
+    using CDP4Common;
+
     using DEHEASysML.DstController;
     using DEHEASysML.Forms;
     using DEHEASysML.ViewModel;
@@ -141,6 +143,57 @@ namespace DEHEASysML.Services.Dispatcher
         public void OpenTransferHistory()
         {
             this.navigationService.ShowDialog<ExchangeHistory>();
+        }
+
+        /// <summary>
+        /// Handle the execution of the EA_OnPostNewPackage event
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository"/></param>
+        /// <param name="value">The id of the created <see cref="Package"/></param>
+        public void OnNewPackage(Repository repository, int value)
+        {
+            this.dstController.OnPackageEvent(repository, ChangeKind.Create,value);
+        }
+
+        /// <summary>
+        /// Handle the execution of the EA_OnPreDeletePackage event
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository"/></param>
+        /// <param name="value">The id of the deleted <see cref="Package"/></param>
+        public void OnDeletePackage(Repository repository, int value)
+        {
+            this.dstController.OnPackageEvent(repository, ChangeKind.Delete, value);
+        }
+
+        /// <summary>
+        /// Handle the OnContextItemChanged event from EA
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository" /></param>
+        /// <param name="guid">The guid of the Item</param>
+        /// <param name="objectType">The <see cref="ObjectType" /> of the item</param>
+        public void OnContextItemChanged(Repository repository, string guid, ObjectType objectType)
+        {
+            this.dstController.OnContextItemChanged(repository, guid, objectType);
+        }
+
+        /// <summary>
+        /// Handle the execution of the EA_OnPostNewElement event
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository"/></param>
+        /// <param name="value">The id of the created <see cref="Element"/></param>
+        public void OnNewElement(Repository repository, int value)
+        {
+            this.dstController.OnElementEvent(repository, ChangeKind.Create, value);
+        }
+
+        /// <summary>
+        /// Handle the execution of the EA_OnPreDeleteElement event
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository"/></param>
+        /// <param name="value">The id of the deleted <see cref="Element"/></param>
+        public void OnDeleteElement(Repository repository, int value)
+        {
+            this.dstController.OnElementEvent(repository, ChangeKind.Delete, value);
         }
 
         /// <summary>

--- a/DEHEASysML/Services/Dispatcher/IDispatcher.cs
+++ b/DEHEASysML/Services/Dispatcher/IDispatcher.cs
@@ -105,5 +105,41 @@ namespace DEHEASysML.Services.Dispatcher
         /// Open the Transfer History dialog
         /// </summary>
         void OpenTransferHistory();
+
+        /// <summary>
+        /// Handle the execution of the EA_OnPostNewPackage event
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository"/></param>
+        /// <param name="value">The id of the created <see cref="Package"/></param>
+        void OnNewPackage(Repository repository, int value);
+
+        /// <summary>
+        /// Handle the execution of the EA_OnPostNewElement event
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository"/></param>
+        /// <param name="value">The id of the created <see cref="Element"/></param>
+        void OnNewElement(Repository repository, int value);
+
+        /// <summary>
+        /// Handle the execution of the EA_OnPreDeleteElement event
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository"/></param>
+        /// <param name="value">The id of the deleted <see cref="Element"/></param>
+        void OnDeleteElement(Repository repository, int value);
+
+        /// <summary>
+        /// Handle the execution of the EA_OnPreDeletePackage event
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository"/></param>
+        /// <param name="value">The id of the deleted <see cref="Package"/></param>
+        void OnDeletePackage(Repository repository, int value);
+
+        /// <summary>
+        /// Handle the OnContextItemChanged event from EA
+        /// </summary>
+        /// <param name="repository">The <see cref="Repository" /></param>
+        /// <param name="guid">The guid of the Item</param>
+        /// <param name="objectType">The <see cref="ObjectType" /> of the item</param>
+        void OnContextItemChanged(Repository repository, string guid, ObjectType objectType);
     }
 }

--- a/DEHEASysML/ViewModel/EnterpriseArchitectObjectBrowser/EnterpriseArchitectObjectBrowserViewModel.cs
+++ b/DEHEASysML/ViewModel/EnterpriseArchitectObjectBrowser/EnterpriseArchitectObjectBrowserViewModel.cs
@@ -28,9 +28,11 @@ namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser
     using System.Collections.Generic;
     using System.Linq;
 
+    using DEHEASysML.ViewModel.Comparers;
     using DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Interfaces;
     using DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows;
 
+    using DEHPCommon.Extensions;
     using DEHPCommon.UserInterfaces.ViewModels;
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
 
@@ -44,6 +46,11 @@ namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser
     /// </summary>
     public class EnterpriseArchitectObjectBrowserViewModel : ReactiveObject, IEnterpriseArchitectObjectBrowserViewModel, IHaveContextMenuViewModel
     {
+        /// <summary>
+        /// The <see cref="EnterpriseArchitectObjectBaseRowViewModel" /> <see cref="IComparer{T}" />
+        /// </summary>
+        protected static readonly IComparer<EnterpriseArchitectObjectBaseRowViewModel> ContainedRowsComparer = new EnterpriseArchitectObjectRowComparer();
+
         /// <summary>
         /// Backing field for <see cref="IsBusy" />
         /// </summary>
@@ -131,7 +138,7 @@ namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser
 
             foreach (var repositoryModel in models.Where(x => packagesIdList.Contains(x.PackageID)))
             {
-                this.Things.Add(new ModelRowViewModel(repositoryModel, visibleElements, packagesIdList));
+                this.Things.SortedInsert(new ModelRowViewModel(repositoryModel, visibleElements, packagesIdList), ContainedRowsComparer);
             }
         }
 

--- a/DEHEASysML/ViewModel/EnterpriseArchitectObjectBrowser/Rows/BlockRowViewModel.cs
+++ b/DEHEASysML/ViewModel/EnterpriseArchitectObjectBrowser/Rows/BlockRowViewModel.cs
@@ -24,9 +24,10 @@
 
 namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows
 {
-    using DEHEASysML.Extensions;
+    using System.Linq;
 
-    using DEHPCommon.Extensions;
+    using DEHEASysML.Enumerators;
+    using DEHEASysML.Extensions;
 
     using EA;
 
@@ -57,20 +58,9 @@ namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows
         {
             if (this.ShouldShowEverything)
             {
-                foreach (var valueProperty in this.RepresentedObject.Elements.GetAllValuePropertiesOfElement())
-                {
-                    this.ContainedRows.SortedInsert(new ValuePropertyRowViewModel(this, valueProperty), ContainedRowsComparer);
-                }
-
-                foreach (var partProperty in this.RepresentedObject.Elements.GetAllPartPropertiesOfElement())
-                {
-                    this.ContainedRows.SortedInsert(new PartPropertyRowViewModel(this, partProperty), ContainedRowsComparer);
-                }
-
-                foreach (var port in this.RepresentedObject.Elements.GetAllPortsOfElement())
-                {
-                    this.ContainedRows.SortedInsert(new PortRowViewModel(this, port), ContainedRowsComparer);
-                }
+                this.UpdateContainedRowsOfStereotype(StereotypeKind.ValueProperty, this.RepresentedObject.Elements.GetAllValuePropertiesOfElement().ToList());
+                this.UpdateContainedRowsOfStereotype(StereotypeKind.PartProperty, this.RepresentedObject.Elements.GetAllPartPropertiesOfElement().ToList());
+                this.UpdateContainedRowsOfStereotype(StereotypeKind.Port, this.RepresentedObject.Elements.GetAllPortsOfElement().ToList());
             }
         }
 

--- a/DEHEASysML/ViewModel/EnterpriseArchitectObjectBrowser/Rows/EnterpriseArchitectObjectBaseRowViewModel.cs
+++ b/DEHEASysML/ViewModel/EnterpriseArchitectObjectBrowser/Rows/EnterpriseArchitectObjectBaseRowViewModel.cs
@@ -24,14 +24,24 @@
 
 namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows
 {
+    using System.Collections.Generic;
+
+    using DEHEASysML.ViewModel.Comparers;
+
     using ReactiveUI;
 
     /// <summary>
-    /// The <see cref="EnterpriseArchitectObjectBaseRowViewModel" /> represents the base of all rows view model to represents an
+    /// The <see cref="EnterpriseArchitectObjectBaseRowViewModel" /> represents the base of all rows view model to represents
+    /// an
     /// Enterprise Architect Object
     /// </summary>
-    public abstract class EnterpriseArchitectObjectBaseRowViewModel : ReactiveObject 
+    public abstract class EnterpriseArchitectObjectBaseRowViewModel : ReactiveObject
     {
+        /// <summary>
+        /// The <see cref="EnterpriseArchitectObjectBaseRowViewModel" /> <see cref="IComparer{T}" />
+        /// </summary>
+        protected static readonly IComparer<EnterpriseArchitectObjectBaseRowViewModel> ContainedRowsComparer = new EnterpriseArchitectObjectRowComparer();
+
         /// <summary>
         /// Backing field for <see cref="Name" />
         /// </summary>
@@ -46,6 +56,21 @@ namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows
         /// Backing field for <see cref="RowType" />
         /// </summary>
         private string rowType;
+
+        /// <summary>
+        /// Backing field for <see cref="IsHighlighted" />
+        /// </summary>
+        private bool isHighlighted;
+
+        /// <summary>
+        /// Backing field for <see cref="Parent" />
+        /// </summary>
+        private EnterpriseArchitectObjectBaseRowViewModel parent;
+
+        /// <summary>
+        /// Backing field for <see cref="IsSelectedForTransfer" />
+        /// </summary>
+        private bool isSelectedForTransfer;
 
         /// <summary>
         /// The name of the represented object
@@ -78,6 +103,33 @@ namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows
         /// The collection of contained <see cref="ContainedRows" />
         /// </summary>
         public ReactiveList<EnterpriseArchitectObjectBaseRowViewModel> ContainedRows { get; } = new();
+
+        /// <summary>
+        /// Gets or sets the value if the row is highlighted
+        /// </summary>
+        public bool IsHighlighted
+        {
+            get => this.isHighlighted;
+            set => this.RaiseAndSetIfChanged(ref this.isHighlighted, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the parent of this row
+        /// </summary>
+        public EnterpriseArchitectObjectBaseRowViewModel Parent
+        {
+            get => this.parent;
+            set => this.RaiseAndSetIfChanged(ref this.parent, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the value if the row is selected for transfer
+        /// </summary>
+        public bool IsSelectedForTransfer
+        {
+            get => this.isSelectedForTransfer;
+            set => this.RaiseAndSetIfChanged(ref this.isSelectedForTransfer, value);
+        }
 
         /// <summary>
         /// Compute the current row to initializes properties

--- a/DEHEASysML/ViewModel/EnterpriseArchitectObjectBrowser/Rows/EnterpriseArchitectObjectRowViewModel.cs
+++ b/DEHEASysML/ViewModel/EnterpriseArchitectObjectBrowser/Rows/EnterpriseArchitectObjectRowViewModel.cs
@@ -24,9 +24,13 @@
 
 namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows
 {
+    using System;
     using System.Collections.Generic;
+    using System.Linq;
 
-    using DEHEASysML.ViewModel.Comparers;
+    using DEHEASysML.Enumerators;
+
+    using DEHPCommon.Extensions;
 
     using EA;
 
@@ -41,29 +45,9 @@ namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows
     public abstract class EnterpriseArchitectObjectRowViewModel<TEaClass> : EnterpriseArchitectObjectBaseRowViewModel where TEaClass : class
     {
         /// <summary>
-        /// The <see cref="EnterpriseArchitectObjectBaseRowViewModel" /> <see cref="IComparer{T}" />
-        /// </summary>
-        protected static readonly IComparer<EnterpriseArchitectObjectBaseRowViewModel> ContainedRowsComparer = new EnterpriseArchitectObjectRowComparer();
-
-        /// <summary>
         /// Backing field for <see cref="RepresentedObject" />
         /// </summary>
         private TEaClass representedObject;
-
-        /// <summary>
-        /// Backing field for <see cref="IsSelectedForTransfer" />
-        /// </summary>
-        private bool isSelectedForTransfer;
-
-        /// <summary>
-        /// Backing field for <see cref="IsHighlighted" />
-        /// </summary>
-        private bool isHighlighted;
-
-        /// <summary>
-        /// Backing field for <see cref="Parent" />
-        /// </summary>
-        private EnterpriseArchitectObjectBaseRowViewModel parent;
 
         /// <summary>
         /// Backing field for <see cref="ToolTip" />
@@ -96,24 +80,6 @@ namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows
         }
 
         /// <summary>
-        /// Gets or sets the value if the row is highlighted
-        /// </summary>
-        public bool IsHighlighted
-        {
-            get => this.isHighlighted;
-            set => this.RaiseAndSetIfChanged(ref this.isHighlighted, value);
-        }
-
-        /// <summary>
-        /// Gets or sets the value if the row is selected for transfer
-        /// </summary>
-        public bool IsSelectedForTransfer
-        {
-            get => this.isSelectedForTransfer;
-            set => this.RaiseAndSetIfChanged(ref this.isSelectedForTransfer, value);
-        }
-
-        /// <summary>
         /// Gets or sets the Tooltip of the row
         /// </summary>
         public string ToolTip
@@ -123,12 +89,13 @@ namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows
         }
 
         /// <summary>
-        /// Gets or sets the parent of this row
+        /// Update the <see cref="RepresentedObject" />
         /// </summary>
-        public EnterpriseArchitectObjectBaseRowViewModel Parent
+        /// <param name="newObject">The new <see cref="TEaClass" /> object</param>
+        public void UpdateRepresentedObject(TEaClass newObject)
         {
-            get => this.parent;
-            set => this.RaiseAndSetIfChanged(ref this.parent, value);
+            this.RepresentedObject = newObject;
+            this.UpdateProperties();
         }
 
         /// <summary>
@@ -152,7 +119,99 @@ namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows
                     break;
             }
 
-            this.ToolTip = $"Row resprensenting : {this.Name} of type {this.RowType}";
+            this.ToolTip = $"Row respresenting : {this.Name} of type {this.RowType}";
+        }
+
+        /// <summary>
+        /// Update the <see cref="EnterpriseArchitectObjectBaseRowViewModel.ContainedRows"/> that correspond to a certain <see cref="StereotypeKind"/>
+        /// to apply the latest changes
+        /// </summary>
+        /// <param name="stereotypeKind">The <see cref="StereotypeKind"/></param>
+        /// <param name="elements">The contained <see cref="Element"/></param>
+        protected void UpdateContainedRowsOfStereotype(StereotypeKind stereotypeKind, List<Element> elements)
+        {
+            var rows = this.GetContainedRowsOfStereotype(stereotypeKind);
+
+            var rowsToUpdate = rows.Where(x =>
+                elements.Any(element => x.RepresentedObject.ElementGUID == element.ElementGUID));
+
+            var rowsToRemoves = rows.Where(x =>
+                elements.All(element => x.RepresentedObject.ElementGUID != element.ElementGUID));
+
+            var elementsToAdd = elements.Where(x =>
+                rows.All(row => row.RepresentedObject.ElementGUID != x.ElementGUID));
+
+            foreach (var row in rowsToUpdate)
+            {
+                row.UpdateElement(elements.FirstOrDefault(x => x.ElementGUID == row.RepresentedObject.ElementGUID));
+            }
+
+            foreach (var elementRowViewModel in rowsToRemoves)
+            {
+                this.ContainedRows.Remove(elementRowViewModel);
+            }
+
+            foreach (var elementToAdd in elementsToAdd)
+            {
+                this.ContainedRows.SortedInsert(this.CreateRow(elementToAdd, stereotypeKind), ContainedRowsComparer);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="EnterpriseArchitectObjectBaseRowViewModel"/> based on an <see cref="Element"/>
+        /// and the <see cref="StereotypeKind"/>
+        /// </summary>
+        /// <param name="element">The <see cref="Element"/></param>
+        /// <param name="stereotypeKind">The <see cref="StereotypeKind"/></param>
+        /// <returns>A newly created <see cref="EnterpriseArchitectObjectBaseRowViewModel"/></returns>
+        protected EnterpriseArchitectObjectBaseRowViewModel CreateRow(Element element, StereotypeKind stereotypeKind)
+        {
+            return stereotypeKind switch
+            {
+                StereotypeKind.State => new StateRowViewModel(this, element),
+                StereotypeKind.Requirement => new ElementRequirementRowViewModel(this, element),
+                StereotypeKind.Block => new BlockRowViewModel(this, element, true),
+                StereotypeKind.PartProperty => new PartPropertyRowViewModel(this, element),
+                StereotypeKind.ValueProperty => new ValuePropertyRowViewModel(this, element),
+                StereotypeKind.Port => new PortRowViewModel(this, element),
+                _ => throw new ArgumentOutOfRangeException(nameof(stereotypeKind), "Stereotype not supported")
+            };
+        }
+
+        /// <summary>
+        /// Gets all <see cref="ElementRowViewModel"/> contained that correspond to a certain <see cref="StereotypeKind"/>
+        /// </summary>
+        /// <param name="stereotypeKind">The <see cref="StereotypeKind"/></param>
+        /// <returns>A collection of <see cref="ElementRowViewModel"/></returns>
+        protected List<ElementRowViewModel> GetContainedRowsOfStereotype(StereotypeKind stereotypeKind)
+        {
+            var rows = new List<ElementRowViewModel>();
+
+            switch (stereotypeKind)
+            {
+                case StereotypeKind.State:
+                    rows.AddRange(this.ContainedRows.OfType<StateRowViewModel>());
+                    break;
+                case StereotypeKind.Requirement:
+                    rows.AddRange(this.ContainedRows.OfType<ElementRequirementRowViewModel>());
+                    break;
+                case StereotypeKind.Block:
+                    rows.AddRange(this.ContainedRows.OfType<BlockRowViewModel>());
+                    break;
+                case StereotypeKind.PartProperty:
+                    rows.AddRange(this.ContainedRows.OfType<PartPropertyRowViewModel>());
+                    break;
+                case StereotypeKind.ValueProperty:
+                    rows.AddRange(this.ContainedRows.OfType<ValuePropertyRowViewModel>());
+                    break;
+                case StereotypeKind.Port:
+                    rows.AddRange(this.ContainedRows.OfType<PortRowViewModel>());
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(stereotypeKind), "Stereotype not supported");
+            }
+
+            return rows;
         }
     }
 }

--- a/DEHEASysML/ViewModel/NetChangePreview/DstNetChangePreviewViewModel.cs
+++ b/DEHEASysML/ViewModel/NetChangePreview/DstNetChangePreviewViewModel.cs
@@ -29,12 +29,15 @@ namespace DEHEASysML.ViewModel.NetChangePreview
     using System.Linq;
     using System.Reactive.Linq;
 
+    using CDP4Common;
     using CDP4Common.CommonData;
 
     using CDP4Dal;
 
     using DEHEASysML.DstController;
+    using DEHEASysML.Enumerators;
     using DEHEASysML.Events;
+    using DEHEASysML.Extensions;
     using DEHEASysML.Utils.Stereotypes;
     using DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser;
     using DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows;
@@ -60,7 +63,7 @@ namespace DEHEASysML.ViewModel.NetChangePreview
         /// <summary>
         /// A collection of <see cref="ElementRowViewModel" /> that are highlighted
         /// </summary>
-        private readonly List<ElementRowViewModel> highlightedRows = new();
+        private readonly List<EnterpriseArchitectObjectBaseRowViewModel> highlightedRows = new();
 
         /// <summary>
         /// Initializes a new <see cref="DstNetChangePreviewViewModel" />
@@ -71,7 +74,7 @@ namespace DEHEASysML.ViewModel.NetChangePreview
             this.dstController = dstController;
 
             this.InitializeCommandsAndObservables();
-            this.ComputeValues();
+            this.ComputeValues(true);
         }
 
         /// <summary>
@@ -108,17 +111,29 @@ namespace DEHEASysML.ViewModel.NetChangePreview
         /// <summary>
         /// Compute all rows
         /// </summary>
-        public void ComputeValues()
+        /// <param name="shouldReset">A value indicating if the tree has to reset or not</param>
+        public void ComputeValues(bool shouldReset)
         {
             if (!this.dstController.IsFileOpen)
             {
+                this.Things.Clear();
                 return;
             }
 
             this.IsBusy = true;
+
+            if (shouldReset)
+            {
+                this.BuildNetChangeTree();
+            }
+            else
+            {
+                this.CleanTree();
+            }
+
             this.SelectedThings.Clear();
             this.highlightedRows.Clear();
-            this.BuildNetChangeTree();
+
             this.ComputeRows();
             this.IsBusy = false;
         }
@@ -171,6 +186,42 @@ namespace DEHEASysML.ViewModel.NetChangePreview
         }
 
         /// <summary>
+        /// Cleans the tree
+        /// </summary>
+        private void CleanTree()
+        {
+            foreach (var row in this.highlightedRows.OfType<ElementRowViewModel>())
+            {
+                row.IsHighlighted = false;
+                row.IsSelectedForTransfer = false;
+
+                var element = this.dstController.CurrentRepository.GetElementByGuid(row.RepresentedObject.ElementGUID);
+
+                if (element != null)
+                {
+                    row.UpdateElement(element);
+                }
+                else
+                {
+                    row.Parent.ContainedRows.Remove(row);
+                }
+            }
+
+            foreach (var row in this.highlightedRows.OfType<PackageRowViewModel>())
+            {
+                row.IsHighlighted = false;
+                row.IsSelectedForTransfer = false;
+
+                var package = this.dstController.CurrentRepository.GetPackageByGuid(row.RepresentedObject.PackageGUID);
+
+                if (package == null)
+                {
+                    row.Parent.ContainedRows.Remove(row);
+                }
+            }
+        }
+
+        /// <summary>
         /// Compute the rows to display the current mapping
         /// </summary>
         private void ComputeRows()
@@ -191,9 +242,8 @@ namespace DEHEASysML.ViewModel.NetChangePreview
                 }
 
                 var row = this.GetOrCreateRow(mappedElement);
-                row.IsHighlighted = true;
 
-                this.highlightedRows.Add(row);
+                this.HighlightRowAndParentRow(row);
 
                 foreach (var valuePropertyRow in row.ContainedRows.OfType<ValuePropertyRowViewModel>())
                 {
@@ -203,11 +253,26 @@ namespace DEHEASysML.ViewModel.NetChangePreview
                     }
                 }
 
-                if (row is ElementRequirementRowViewModel requirementRow 
+                if (row is ElementRequirementRowViewModel requirementRow
                     && this.dstController.UpdatedRequirementValues.TryGetValue(mappedElement.ElementGUID, out var newRequirementValue))
                 {
                     requirementRow.OverrideValue(newRequirementValue.text);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Highlight a row and the parent of this row
+        /// </summary>
+        /// <param name="row">The row to highlight</param>
+        private void HighlightRowAndParentRow(EnterpriseArchitectObjectBaseRowViewModel row)
+        {
+            row.IsHighlighted = true;
+            this.highlightedRows.Add(row);
+
+            if (row.Parent is { IsHighlighted: false })
+            {
+                this.HighlightRowAndParentRow(row.Parent);
             }
         }
 
@@ -218,7 +283,8 @@ namespace DEHEASysML.ViewModel.NetChangePreview
         /// <returns>A <see cref="ElementRowViewModel" /></returns>
         private ElementRowViewModel GetOrCreateRow(Element mappedElement)
         {
-            var highlightedRow = this.highlightedRows.FirstOrDefault(x => x.RepresentedObject.ElementGUID == mappedElement.ElementGUID);
+            var highlightedRow = this.highlightedRows
+                .OfType<ElementRowViewModel>().FirstOrDefault(x => x.RepresentedObject.ElementGUID == mappedElement.ElementGUID);
 
             if (highlightedRow != null)
             {
@@ -262,7 +328,14 @@ namespace DEHEASysML.ViewModel.NetChangePreview
         /// </summary>
         private void InitializeCommandsAndObservables()
         {
-            CDPMessageBus.Current.Listen<UpdateDstNetChangePreview>().Subscribe(_ => this.ComputeValues());
+            CDPMessageBus.Current.Listen<UpdateDstNetChangePreview>()
+                .Subscribe(x => this.ComputeValues(x.Reset));
+
+            CDPMessageBus.Current.Listen<EnterpriseArchitectPackageEvent>()
+                .Subscribe(x => this.AddOrRemovePackageRow(x.Id, x.ChangeKind));
+
+            CDPMessageBus.Current.Listen<EnterpriseArchitectElementEvent>()
+                .Subscribe(x => this.AddOrRemoveElementRow(x.Id, x.ChangeKind));
 
             this.SelectedThings.BeforeItemsAdded.Subscribe(this.WhenItemSelectedChanges);
             this.SelectedThings.BeforeItemsRemoved.Subscribe(this.WhenItemSelectedChanges);
@@ -277,9 +350,101 @@ namespace DEHEASysML.ViewModel.NetChangePreview
         }
 
         /// <summary>
+        /// Adds or removes <see cref="ElementRowViewModel" />
+        /// </summary>
+        /// <param name="elementId">The id of the <see cref="Element" /></param>
+        /// <param name="changeKind">The <see cref="ChangeKind" /></param>
+        private void AddOrRemoveElementRow(int elementId, ChangeKind changeKind)
+        {
+            this.IsBusy = true;
+
+            var element = this.dstController.CurrentRepository.GetElementByID(elementId);
+
+            if (element.Stereotype.AreEquals(StereotypeKind.Block) || element.Stereotype.AreEquals(StereotypeKind.Requirement)
+                                                                   || element.Stereotype.AreEquals(StereotypeKind.State))
+            {
+                var row = this.GetOrCreateRow(element);
+
+                if (changeKind == ChangeKind.Delete)
+                {
+                    row.Parent.ContainedRows.Remove(row);
+                }
+            }
+            else if (element.Stereotype.AreEquals(StereotypeKind.Port) || element.Stereotype.AreEquals(StereotypeKind.PartProperty)
+                                                                       || element.Stereotype.AreEquals(StereotypeKind.ValueProperty))
+            {
+                var blockElement = this.dstController.CurrentRepository.GetElementByID(element.ParentID);
+
+                var parentRow = this.GetOrCreateRow(blockElement);
+
+                if (changeKind == ChangeKind.Delete)
+                {
+                    foreach (var containedRwows in parentRow.ContainedRows.OfType<ElementRowViewModel>()
+                                 .Where(containedRwows => containedRwows.RepresentedObject.ElementID == elementId).ToList())
+                    {
+                        containedRwows.Parent.ContainedRows.Remove(containedRwows);
+                    }
+                }
+            }
+
+            this.IsBusy = false;
+        }
+
+        /// <summary>
+        /// Adds or removes <see cref="PackageRowViewModel" />
+        /// </summary>
+        /// <param name="packageId">The id of the <see cref="Package" /></param>
+        /// <param name="changeKind">The <see cref="ChangeKind" /></param>
+        private void AddOrRemovePackageRow(int packageId, ChangeKind changeKind)
+        {
+            this.IsBusy = true;
+
+            var package = this.dstController.CurrentRepository.GetPackageByID(packageId);
+
+            var packageRow = this.GetOrCreatePackageRow(package);
+
+            if (changeKind == ChangeKind.Delete)
+            {
+                packageRow.Parent.ContainedRows.Remove(packageRow);
+            }
+
+            this.IsBusy = false;
+        }
+
+        /// <summary>
+        /// Gets or create the <see cref="PackageRowViewModel" /> representing the <see cref="Package" />
+        /// </summary>
+        /// <param name="package">The <see cref="Package" /></param>
+        /// <returns>The <see cref="PackageRowViewModel" /></returns>
+        private PackageRowViewModel GetOrCreatePackageRow(Package package)
+        {
+            var packagesId = new List<int>();
+            this.dstController.GetPackageParentId(package.PackageID, ref packagesId);
+
+            if (packagesId.Count > 1)
+            {
+                packagesId.RemoveAt(0);
+            }
+
+            packagesId.Reverse();
+
+            foreach (var modelRow in this.Things.OfType<ModelRowViewModel>())
+            {
+                var row = modelRow.GetOrCreatePackageRowViewModel(package, packagesId);
+
+                if (row != null)
+                {
+                    return row;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// The <see cref="Element" />
         /// </summary>
-        /// <param name="elementRow">The <see cref="ElementRowViewModel"/></param>
+        /// <param name="elementRow">The <see cref="ElementRowViewModel" /></param>
         private void AddOrRemoveToSelectedThingsToTransfer(ElementRowViewModel elementRow)
         {
             this.AddOrRemoveToSelectedThingsToTransfer(elementRow.RepresentedObject, elementRow.IsSelectedForTransfer);

--- a/DEHEASysML/ViewModel/NetChangePreview/HubObjectNetChangePreviewViewModel.cs
+++ b/DEHEASysML/ViewModel/NetChangePreview/HubObjectNetChangePreviewViewModel.cs
@@ -41,7 +41,9 @@ namespace DEHEASysML.ViewModel.NetChangePreview
     using DEHPCommon.HubController.Interfaces;
     using DEHPCommon.Services.ObjectBrowserTreeSelectorService;
     using DEHPCommon.UserInterfaces.ViewModels;
+    using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
     using DEHPCommon.UserInterfaces.ViewModels.NetChangePreview;
+    using DEHPCommon.UserInterfaces.ViewModels.Rows;
     using DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows;
 
     using ReactiveUI;
@@ -128,17 +130,16 @@ namespace DEHEASysML.ViewModel.NetChangePreview
         {
             switch (row)
             {
+                case ParameterRowViewModel parameterRowViewModel when this.IsThingTransferable(parameterRowViewModel.Thing):
+                    this.WhenItemSelectedChanges(parameterRowViewModel);
+                    break;
+
+                case ElementUsageRowViewModel elementUsageRowViewModel when this.IsThingTransferable(elementUsageRowViewModel.Thing):
+                    this.WhenItemSelectedChanges(elementUsageRowViewModel);
+                    break;
+
                 case ElementDefinitionRowViewModel elementDefinitionRow when this.IsThingTransferable(elementDefinitionRow.Thing):
-                    elementDefinitionRow.IsSelectedForTransfer = !elementDefinitionRow.IsSelectedForTransfer;
-                    this.AddOrRemoveToSelectedThingsToTransfer(elementDefinitionRow);
-                    break;
-
-                case ParameterOrOverrideBaseRowViewModel parameterRow:
-                    this.WhenItemSelectedChanges(parameterRow.ContainerViewModel);
-                    break;
-
-                case ParameterGroupRowViewModel parameterGroupRow:
-                    this.WhenItemSelectedChanges(parameterGroupRow.ContainerViewModel);
+                    this.SelectDeselectElementDefinitionRowToTransfer(elementDefinitionRow);
                     break;
             }
         }
@@ -151,9 +152,8 @@ namespace DEHEASysML.ViewModel.NetChangePreview
         {
             foreach (var hubElement in this.mappedBlocks.Select(x => x.HubElement))
             {
-                this.AddOrRemoveToSelectedThingsToTransfer(hubElement, areSelected);
                 this.GetElementDefinitionRowViewModel(hubElement, out var elementDefinitionRowViewModel);
-                elementDefinitionRowViewModel.IsSelectedForTransfer = areSelected;
+                this.SelectDeselectElementDefinitionRowToTransfer(elementDefinitionRowViewModel, areSelected);
             }
         }
 
@@ -183,6 +183,107 @@ namespace DEHEASysML.ViewModel.NetChangePreview
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Select or deselect an <see cref="ElementDefinitionRowViewModel" /> to transfer
+        /// </summary>
+        /// <param name="elementDefinitionRow">The <see cref="ElementDefinitionRowViewModel" /></param>
+        private void SelectDeselectElementDefinitionRowToTransfer(ElementDefinitionRowViewModel elementDefinitionRow)
+        {
+            this.SelectDeselectElementDefinitionRowToTransfer(elementDefinitionRow, !elementDefinitionRow.IsSelectedForTransfer);
+        }
+
+        /// <summary>
+        /// Select or deselect an <see cref="ElementDefinitionRowViewModel" /> to transfer
+        /// </summary>
+        /// <param name="elementDefinitionRow">the <see cref="ElementDefinitionRowViewModel" /></param>
+        /// <param name="isSelected">A value indicating if the <see cref="ElementDefinitionRowViewModel" /> is selected or not</param>
+        private void SelectDeselectElementDefinitionRowToTransfer(ElementDefinitionRowViewModel elementDefinitionRow, bool isSelected)
+        {
+            elementDefinitionRow.IsSelectedForTransfer = isSelected;
+
+            foreach (var transferableRow in this.GetAllTransferableRows(elementDefinitionRow))
+            {
+                switch (transferableRow)
+                {
+                    case ParameterRowViewModel parameterRow:
+                        parameterRow.IsSelectedForTransfer = elementDefinitionRow.IsSelectedForTransfer;
+                        break;
+                    case ElementUsageRowViewModel elementUsageRow:
+                        elementUsageRow.IsSelectedForTransfer = elementDefinitionRow.IsSelectedForTransfer;
+                        break;
+                }
+            }
+
+            this.AddOrRemoveToSelectedThingsToTransfer(elementDefinitionRow);
+        }
+
+        /// <summary>
+        /// Retrieves all transferable rows contained inside a <see cref="IHaveContainedRows" />
+        /// </summary>
+        /// <param name="row">The <see cref="IHaveContainedRows" /></param>
+        /// <returns>A collection of transferable rows</returns>
+        private IEnumerable<IHaveContainerViewModel> GetAllTransferableRows(IHaveContainedRows row)
+        {
+            var transferableRows = new List<IHaveContainerViewModel>();
+
+            foreach (var containedRow in row.ContainedRows)
+            {
+                switch (containedRow)
+                {
+                    case ElementUsageRowViewModel elementUsageRow:
+                        transferableRows.Add(elementUsageRow);
+                        break;
+
+                    case ParameterRowViewModel parameterRow:
+                        transferableRows.Add(parameterRow);
+                        break;
+                    case ParameterGroupRowViewModel parameterGroupRow:
+                        transferableRows.AddRange(this.GetAllTransferableRows(parameterGroupRow));
+                        break;
+                }
+            }
+
+            return transferableRows;
+        }
+
+        /// <summary>
+        /// Occurs when a <see cref="RowViewModelBase{TThing}" /> has been selected or deselected
+        /// </summary>
+        /// <typeparam name="TThing">A <see cref="Thing" /></typeparam>
+        /// <param name="row">The <see cref="RowViewModelBase{TThing}" /></param>
+        private void WhenItemSelectedChanges<TThing>(RowViewModelBase<TThing> row) where TThing : Thing
+        {
+            row.IsSelectedForTransfer = !row.IsSelectedForTransfer;
+
+            if (row.ContainerViewModel is ElementDefinitionRowViewModel elementDefinitionRow)
+            {
+                elementDefinitionRow.IsSelectedForTransfer = this.IsAnyChildrenSelectedForTransfer(elementDefinitionRow);
+            }
+
+            this.AddOrRemoveToSelectedThingsToTransfer(row.Thing, row.IsSelectedForTransfer);
+        }
+
+        /// <summary>
+        /// Verifies in all children of this row if there is any row selected for transfer
+        /// </summary>
+        /// <param name="row">The row to check the children</param>
+        /// <returns>True if any of the children is selected</returns>
+        private bool IsAnyChildrenSelectedForTransfer(IHaveContainedRows row)
+        {
+            foreach (var children in row.ContainedRows)
+            {
+                switch (children)
+                {
+                    case ParameterGroupRowViewModel parameterGroupRowViewModel when this.IsAnyChildrenSelectedForTransfer(parameterGroupRowViewModel):
+                    case ParameterOrOverrideBaseRowViewModel { IsSelectedForTransfer: true }:
+                    case ElementUsageRowViewModel { IsSelectedForTransfer: true }:
+                        return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -225,6 +326,16 @@ namespace DEHEASysML.ViewModel.NetChangePreview
         }
 
         /// <summary>
+        /// Verifies that the <see cref="Thing" /> is transferable
+        /// </summary>
+        /// <param name="thing">The <see cref="Thing" /></param>
+        /// <returns>An assert</returns>
+        private bool IsThingTransferable(Thing thing)
+        {
+            return thing.Container is ElementDefinition elementDefinition && this.IsThingTransferable(elementDefinition);
+        }
+
+        /// <summary>
         /// Adds or removes an <see cref="ElementDefinitionRowViewModel" /> to the selected thing to transfer
         /// </summary>
         /// <param name="elementDefinitionRow">The <see cref="ElementDefinitionRowViewModel" /></param>
@@ -240,12 +351,30 @@ namespace DEHEASysML.ViewModel.NetChangePreview
         /// <param name="isSelected">A value indicating wheter to select the element for transfer</param>
         private void AddOrRemoveToSelectedThingsToTransfer(ElementDefinition elementDefinition, bool isSelected)
         {
+            foreach (var parameter in elementDefinition.Parameter)
+            {
+                this.AddOrRemoveToSelectedThingsToTransfer(parameter, isSelected);
+            }
+
+            foreach (var elementUsage in elementDefinition.ContainedElement)
+            {
+                this.AddOrRemoveToSelectedThingsToTransfer(elementUsage, isSelected);
+            }
+        }
+
+        /// <summary>
+        /// Adds or removes a <see cref="Thing" /> to the selected thing to transfer
+        /// </summary>
+        /// <param name="thing">The <see cref="Thing" /></param>
+        /// <param name="isSelected">A value indicating wheter to select the element for transfer</param>
+        private void AddOrRemoveToSelectedThingsToTransfer(Thing thing, bool isSelected)
+        {
             this.dstController.SelectedDstMapResultForTransfer.RemoveAll(this.dstController.SelectedDstMapResultForTransfer
-                .Where(x => x.Iid == elementDefinition.Iid).ToList());
+                .Where(x => x.Iid == thing.Iid).ToList());
 
             if (isSelected)
             {
-                this.dstController.SelectedDstMapResultForTransfer.Add(elementDefinition);
+                this.dstController.SelectedDstMapResultForTransfer.Add(thing);
             }
         }
 
@@ -291,6 +420,30 @@ namespace DEHEASysML.ViewModel.NetChangePreview
             }
 
             elementDefinitionRowViewModel.IsHighlighted = true;
+            this.HighlightContainedRows(elementDefinitionRowViewModel);
+        }
+
+        /// <summary>
+        /// Highlighs all rows contained inside the <see cref="IHaveContainedRows" />
+        /// </summary>
+        /// <param name="container">The <see cref="IHaveContainedRows" /></param>
+        private void HighlightContainedRows(IHaveContainedRows container)
+        {
+            foreach (var containedRow in container.ContainedRows)
+            {
+                switch (containedRow)
+                {
+                    case ParameterOrOverrideBaseRowViewModel parameterOrOverrideBaseRowViewModel:
+                        parameterOrOverrideBaseRowViewModel.IsHighlighted = true;
+                        break;
+                    case ElementUsageRowViewModel elementUsageRowViewModel:
+                        elementUsageRowViewModel.IsHighlighted = true;
+                        break;
+                    case ParameterGroupRowViewModel parameterGroupRowView:
+                        this.HighlightContainedRows(parameterGroupRowView);
+                        break;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEH-EASYSML/pulls) open
- [x] I have verified that I am following the DEH-EASYSML [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEH-EASYSML/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #40 and #44 

- The user is able to select some parameter(s) or ElementUsage(s) to transfer and not only the ElementDefinition. Only selected Things are transfered and not the whole ElementDefinition
- The DstNetChangePreview does not rebuild the tree on each changes. It reacts to individual changes and update Elements instead of recreating the view
 
<!-- Thanks for contributing to DEH-EASYSML! -->