### PR TITLE
Custom stereotype mapping enable: fix #54

### DIFF
--- a/DEHEASysML.Tests/DstController/DstControllerTestFixture.cs
+++ b/DEHEASysML.Tests/DstController/DstControllerTestFixture.cs
@@ -128,16 +128,17 @@ namespace DEHEASysML.Tests.DstController
 
             var valueTypeElement = new Mock<Element>();
             valueTypeElement.Setup(x => x.Stereotype).Returns(StereotypeKind.ValueType.ToString());
+            valueTypeElement.Setup(x => x.HasStereotype(StereotypeKind.ValueType.ToString())).Returns(true);
             valueTypePackage.Setup(x => x.Elements).Returns(new EnterpriseArchitectCollection() {valueTypeElement.Object });
             valueTypePackage.Setup(x => x.Packages).Returns(new EnterpriseArchitectCollection());
 
             this.blockElement = new Mock<Element>();
-            this.blockElement.Setup(x => x.Stereotype).Returns(StereotypeKind.Block.ToString());
+            this.blockElement.Setup(x => x.HasStereotype(StereotypeKind.Block.ToString().ToLower())).Returns(true);
             this.blockElement.Setup(x => x.ElementGUID).Returns(Guid.NewGuid().ToString);
             blocPackage.Setup(x => x.Elements).Returns(new EnterpriseArchitectCollection() { this.blockElement.Object });
 
             var requirement = new Mock<Element>();
-            requirement.Setup(x => x.Stereotype).Returns(StereotypeKind.Requirement.ToString());
+            requirement.Setup(x => x.HasStereotype(StereotypeKind.Requirement.ToString().ToLower())).Returns(true);
             requirementPackage.Setup(x => x.Elements).Returns(new EnterpriseArchitectCollection() { requirement.Object });
             requirement.Setup(x => x.ElementGUID).Returns(Guid.NewGuid().ToString);
             this.package.Setup(x => x.Packages).Returns(new EnterpriseArchitectCollection() { requirementPackage.Object, blocPackage.Object });
@@ -186,6 +187,7 @@ namespace DEHEASysML.Tests.DstController
             Assert.IsEmpty(this.dstController.UpdatedRequirementValues);
             Assert.IsNull(this.dstController.IsBusy);
             Assert.IsFalse(this.dstController.IsFileOpen);
+            Assert.NotNull(this.dstController.UpdatePropertyTypes);
         }
 
         [Test]
@@ -299,12 +301,12 @@ namespace DEHEASysML.Tests.DstController
             Assert.IsEmpty(this.dstController.GetAllSelectedElements(this.repository.Object));
 
             var block = new Mock<Element>();
-            block.Setup(x => x.Stereotype).Returns(StereotypeKind.Block.ToString());
+            block.Setup(x => x.HasStereotype(StereotypeKind.Block.ToString().ToLower())).Returns(true);
             collection.Add(block.Object);
             Assert.AreEqual(1,this.dstController.GetAllSelectedElements(this.repository.Object).Count());
 
             var requirement = new Mock<Element>();
-            requirement.Setup(x => x.Stereotype).Returns(StereotypeKind.Block.ToString());
+            requirement.Setup(x => x.HasStereotype(StereotypeKind.Requirement.ToString().ToLower())).Returns(true);
             collection.Add(requirement.Object);
             Assert.AreEqual(2, this.dstController.GetAllSelectedElements(this.repository.Object).Count());
 
@@ -652,6 +654,7 @@ namespace DEHEASysML.Tests.DstController
             var element = new Mock<Element>();
             element.Setup(x => x.Name).Returns("element");
             element.Setup(x => x.Stereotype).Returns("block");
+            element.Setup(x => x.HasStereotype(StereotypeKind.Block.ToString().ToLower())).Returns(true);
 
             this.repository.Setup(x => x.GetElementsByQuery("Simple", "element")).Returns(new EnterpriseArchitectCollection()
             {
@@ -686,7 +689,7 @@ namespace DEHEASysML.Tests.DstController
             this.repository.Setup(x => x.RefreshModelView(0));
 
             var requirement = new Mock<Element>();
-            requirement.Setup(x => x.Stereotype).Returns(StereotypeKind.Requirement.ToString());
+            requirement.Setup(x => x.HasStereotype(StereotypeKind.Requirement.ToString().ToLower())).Returns(true);
             requirement.Setup(x => x.ElementGUID).Returns(Guid.NewGuid().ToString());
             requirement.Setup(x => x.PackageID).Returns(1);
 
@@ -708,8 +711,10 @@ namespace DEHEASysML.Tests.DstController
             this.dstController.CreatedElements.Add(requirement.Object);
 
             var block = new Mock<Element>();
-            block.Setup(x => x.Stereotype).Returns(StereotypeKind.Block.ToString());
+            block.Setup(x => x.HasStereotype(StereotypeKind.Block.ToString().ToLower())).Returns(true);
             block.Setup(x => x.ElementGUID).Returns(Guid.NewGuid().ToString());
+
+            this.dstController.UpdatedStereotypes[block.Object.ElementGUID] = "customBlock";
 
             var customProperty = new Mock<CustomProperty>();
             customProperty.Setup(x => x.Name).Returns("default");

--- a/DEHEASysML.Tests/MappingRules/BlockDefinitionToElementDefinitionMappingRuleTestFixture.cs
+++ b/DEHEASysML.Tests/MappingRules/BlockDefinitionToElementDefinitionMappingRuleTestFixture.cs
@@ -173,6 +173,7 @@ namespace DEHEASysML.Tests.MappingRules
 
             this.block = new Mock<Element>();
             this.block.Setup(x => x.Name).Returns("AName");
+            this.block.Setup(x => x.GetStereotypeList()).Returns("block,aStereotype");
 
             var embeddedElement = new EnterpriseArchitectCollection();
 
@@ -403,6 +404,7 @@ namespace DEHEASysML.Tests.MappingRules
             var partBlock = new Mock<Element>();
             partBlock.Setup(x => x.Name).Returns("anOtherBlock");
             partBlock.Setup(x => x.EmbeddedElements).Returns(new EnterpriseArchitectCollection());
+            partBlock.Setup(x => x.GetStereotypeList()).Returns("block");
 
             this.repository.Setup(x => x.GetElementByID(42)).Returns(partBlock.Object);
             this.block.Setup(x => x.EmbeddedElements).Returns(new EnterpriseArchitectCollection() { partProperty.Object });

--- a/DEHEASysML.Tests/MappingRules/ElementDefinitionToBlockMappingRuleTestFixture.cs
+++ b/DEHEASysML.Tests/MappingRules/ElementDefinitionToBlockMappingRuleTestFixture.cs
@@ -150,7 +150,14 @@ namespace DEHEASysML.Tests.MappingRules
             {
                 Iid = Guid.NewGuid(),
                 Name = "ElementDefinition",
-                Parameter = { parameter }
+                Parameter = { parameter },
+                Category =
+                {
+                    new Category()
+                    {
+                        Name = "block"
+                    }
+                }
             };
 
             var mappedElements = new List<ElementDefinitionMappedElement>()

--- a/DEHEASysML.Tests/MappingRules/HubRequirementToDstRequirementMappingRuleTestFixture.cs
+++ b/DEHEASysML.Tests/MappingRules/HubRequirementToDstRequirementMappingRuleTestFixture.cs
@@ -31,6 +31,7 @@ namespace DEHEASysML.Tests.MappingRules
 
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
 
     using DEHEASysML.DstController;
     using DEHEASysML.Enumerators;
@@ -59,17 +60,20 @@ namespace DEHEASysML.Tests.MappingRules
         private Mock<IDstController> dstController;
         private Mock<IMappingConfigurationService> mappingConfiguration;
         private Dictionary<string, (string, string)> requirementValues;
-        
+        private Dictionary<string, string> updatedStereotypes;
+
         [SetUp]
         public void Setup()
         {
             var defaultPackage = new Mock<Package>();
             defaultPackage.Setup(x => x.Elements);
 
+            this.updatedStereotypes = new Dictionary<string, string>();
             this.requirementValues = new Dictionary<string, (string, string)>();
             this.hubController = new Mock<IHubController>();
             this.dstController = new Mock<IDstController>();
             this.dstController.Setup(x => x.UpdatedRequirementValues).Returns(this.requirementValues);
+            this.dstController.Setup(x => x.UpdatedStereotypes).Returns(this.updatedStereotypes);
             this.dstController.Setup(x => x.GetDefaultPackage(It.IsAny<StereotypeKind>())).Returns(defaultPackage.Object);
             this.mappingConfiguration = new Mock<IMappingConfigurationService>();
 
@@ -109,6 +113,17 @@ namespace DEHEASysML.Tests.MappingRules
                     {
                         Content = "a definiton",
                         LanguageCode = "en"
+                    }
+                },
+                Category =
+                {
+                    new Category()
+                    {
+                        Name = "requirement"
+                    },
+                    new Category()
+                    {
+                        Name ="customRequirement"
                     }
                 }
             };

--- a/DEHEASysML.Tests/MappingRules/RequirementElementToRequirementMappingRuleTestFixture.cs
+++ b/DEHEASysML.Tests/MappingRules/RequirementElementToRequirementMappingRuleTestFixture.cs
@@ -149,16 +149,20 @@ namespace DEHEASysML.Tests.MappingRules
 
             var firstRequirement = this.CreateRequirement(subModelPackage.Object.PackageID,"First requirement", "M001", "A simple text");
             firstRequirement.Setup(x => x.Connectors).Returns(new EnterpriseArchitectCollection());
+            firstRequirement.Setup(x => x.GetStereotypeList()).Returns("requirement,aStereotype");
 
             var secondRequirement = this.CreateRequirement(subSubModelPackage.Object.PackageID, "Second requirement", "M002", "A simple text v2");
             secondRequirement.Setup(x => x.Connectors).Returns(new EnterpriseArchitectCollection());
+            secondRequirement.Setup(x => x.GetStereotypeList()).Returns("requirement");
 
             var thirdRequirement = this.CreateRequirement(subSubSubModelPackage.Object.PackageID, "Third requirement", "M003", "A simple text v3");
             thirdRequirement.Setup(x => x.Connectors).Returns(new EnterpriseArchitectCollection());
+            thirdRequirement.Setup(x => x.GetStereotypeList()).Returns("requirement");
 
             var forthRequirement = this.CreateRequirement(subSubSubSubModelPackage.Object.PackageID, "Forth requirement", "M004", "A simple text v4");
             var connector = new Mock<Connector>();
             connector.Setup(x => x.Stereotype).Returns(StereotypeKind.DeriveReqt.ToString());
+            forthRequirement.Setup(x => x.GetStereotypeList()).Returns("requirement");
 
             forthRequirement.Setup(x => x.Connectors).Returns(new EnterpriseArchitectCollection()
             {

--- a/DEHEASysML.Tests/Services/MappingConfiguration/MappingConfigurationServiceTestFixture.cs
+++ b/DEHEASysML.Tests/Services/MappingConfiguration/MappingConfigurationServiceTestFixture.cs
@@ -69,7 +69,7 @@ namespace DEHEASysML.Tests.Services.MappingConfiguration
             var element = new Mock<Element>();
             var guid = Guid.NewGuid();
             element.Setup(x => x.ElementGUID).Returns(guid.ToString());
-            element.Setup(x => x.Stereotype).Returns(stereotype.ToString());
+            element.Setup(x => x.HasStereotype(stereotype.ToString().ToLower())).Returns(true);
             this.repository.Setup(x => x.GetElementByGuid(element.Object.ElementGUID)).Returns(element.Object);
             return element;
         }

--- a/DEHEASysML.Tests/ViewModel/Dialogs/DstMappingConfigurationDialogViewModelTestFixture.cs
+++ b/DEHEASysML.Tests/ViewModel/Dialogs/DstMappingConfigurationDialogViewModelTestFixture.cs
@@ -122,7 +122,8 @@ namespace DEHEASysML.Tests.ViewModel.Dialogs
             var element = new Mock<Element>();
             var guid = Guid.NewGuid();
             element.Setup(x => x.ElementGUID).Returns(guid.ToString());
-            element.Setup(x => x.Stereotype).Returns(stereotype.ToString());
+            element.Setup(x => x.HasStereotype(stereotype.ToString().ToLower())).Returns(true);
+            element.Setup(x => x.StereotypeEx).Returns(stereotype.ToString());
             return element;
         }
 

--- a/DEHEASysML.Tests/ViewModel/Dialogs/HubMappingConfigurationDialogViewModelTestFixture.cs
+++ b/DEHEASysML.Tests/ViewModel/Dialogs/HubMappingConfigurationDialogViewModelTestFixture.cs
@@ -127,7 +127,8 @@ namespace DEHEASysML.Tests.ViewModel.Dialogs
             var element = new Mock<Element>();
             var guid = Guid.NewGuid();
             element.Setup(x => x.ElementGUID).Returns(guid.ToString());
-            element.Setup(x => x.Stereotype).Returns(stereotype.ToString());
+            element.Setup(x => x.StereotypeEx).Returns(stereotype.ToString());
+            element.Setup(x => x.HasStereotype(stereotype.ToString().ToLower())).Returns(true);
             return element;
         }
 

--- a/DEHEASysML.Tests/ViewModel/NetChangePreview/DstNetChangePreviewViewModelTestFixture.cs
+++ b/DEHEASysML.Tests/ViewModel/NetChangePreview/DstNetChangePreviewViewModelTestFixture.cs
@@ -65,12 +65,14 @@ namespace DEHEASysML.Tests.ViewModel.NetChangePreview
         private Mock<Element> valueType;
         private Mock<Repository> repository;
         private Dictionary<string, string> updatedValues;
+        private Dictionary<string, string> updatedStereotypes;
         private Dictionary<string, (string,string)> updatedRequirementValues;
-
+        
         [SetUp]
         public void Setup()
         {
             this.updatedValues = new Dictionary<string, string>();
+            this.updatedStereotypes = new Dictionary<string, string>();
             this.updatedRequirementValues = new Dictionary<string, (string, string)>();
             this.hubMapResult = new ReactiveList<IMappedElementRowViewModel>();
             this.selectedMapElements = new ReactiveList<Element>();
@@ -80,6 +82,7 @@ namespace DEHEASysML.Tests.ViewModel.NetChangePreview
             this.dstController.Setup(x => x.IsFileOpen).Returns(false);
             this.dstController.Setup(x => x.UpdatedValuePropretyValues).Returns(this.updatedValues);
             this.dstController.Setup(x => x.UpdatedRequirementValues).Returns(this.updatedRequirementValues);
+            this.dstController.Setup(x => x.UpdatedStereotypes).Returns(this.updatedStereotypes);
 
             this.viewModel = new DstNetChangePreviewViewModel(this.dstController.Object);
             this.models = new List<Package>();
@@ -89,16 +92,18 @@ namespace DEHEASysML.Tests.ViewModel.NetChangePreview
             this.requirement = new Mock<Element>();
             this.requirement.Setup(x => x.Name).Returns("A requirement");
             this.requirement.Setup(x => x.ElementGUID).Returns("0001");
-            this.requirement.Setup(x => x.Stereotype).Returns(StereotypeKind.Requirement.ToString());
+            this.requirement.Setup(x => x.StereotypeEx).Returns(StereotypeKind.Requirement.ToString());
             this.requirement.Setup(x => x.TaggedValuesEx).Returns(new EnterpriseArchitectCollection() { taggedValue.Object });
             this.requirement.Setup(x => x.ElementGUID).Returns(Guid.NewGuid().ToString());
+            this.requirement.Setup(x => x.HasStereotype(StereotypeKind.Requirement.ToString().ToLower())).Returns(true);
+            this.updatedStereotypes[this.requirement.Object.ElementGUID] = "aCustomStereotype";
 
             var valueProperty = new Mock<Element>();
-            valueProperty.Setup(x => x.Stereotype).Returns(StereotypeKind.ValueProperty.ToString());
+            valueProperty.Setup(x => x.StereotypeEx).Returns(StereotypeKind.ValueProperty.ToString());
             valueProperty.Setup(x => x.Name).Returns("mass");
             valueProperty.Setup(x => x.ElementGUID).Returns(Guid.NewGuid().ToString());
             var partProperty = new Mock<Element>();
-            partProperty.Setup(x => x.Stereotype).Returns(StereotypeKind.PartProperty.ToString());
+            partProperty.Setup(x => x.StereotypeEx).Returns(StereotypeKind.PartProperty.ToString());
             partProperty.Setup(x => x.Name).Returns("a contained element");
             var taggedValueProperty = new Mock<TaggedValue>();
             taggedValueProperty.Setup(x => x.Name).Returns("default");
@@ -107,7 +112,8 @@ namespace DEHEASysML.Tests.ViewModel.NetChangePreview
             this.block = new Mock<Element>();
             this.block.Setup(x => x.Name).Returns("a Block");
             this.block.Setup(x => x.ElementGUID).Returns("0002");
-            this.block.Setup(x => x.Stereotype).Returns(StereotypeKind.Block.ToString());
+            this.block.Setup(x => x.StereotypeEx).Returns(StereotypeKind.Block.ToString());
+            this.block.Setup(x => x.HasStereotype(StereotypeKind.Block.ToString().ToLower())).Returns(true);
             
             this.block.Setup(x => x.Elements).Returns(new EnterpriseArchitectCollection()
             {
@@ -117,7 +123,7 @@ namespace DEHEASysML.Tests.ViewModel.NetChangePreview
             this.valueType = new Mock<Element>();
             this.valueType.Setup(x => x.Name).Returns("a ValueType");
             this.valueType.Setup(x => x.ElementGUID).Returns("0003");
-            this.valueType.Setup(x => x.Stereotype).Returns(StereotypeKind.ValueType.ToString());
+            this.valueType.Setup(x => x.StereotypeEx).Returns(StereotypeKind.ValueType.ToString());
 
             var subPackage = new Mock<Package>();
             subPackage.Setup(x => x.PackageID).Returns(3);
@@ -232,7 +238,8 @@ namespace DEHEASysML.Tests.ViewModel.NetChangePreview
             element.Setup(x => x.ElementID).Returns(145);
             element.Setup(x => x.Elements).Returns(new EnterpriseArchitectCollection());
             element.Setup(x => x.PackageID).Returns(package.Object.PackageID);
-            element.Setup(x => x.Stereotype).Returns(StereotypeKind.Block.ToString());
+            element.Setup(x => x.StereotypeEx).Returns(StereotypeKind.Block.ToString());
+            element.Setup(x => x.HasStereotype(StereotypeKind.Block.ToString().ToLower())).Returns(true);
 
             this.dstController.Setup(x => x.GetPackageParentId(package.Object.PackageID, ref It.Ref<List<int>>.IsAny))
                 .Callback(new GetPackageParentIdDelegate(((int id, ref List<int> idsList) => idsList = idList)));

--- a/DEHEASysML/DstController/IDstController.cs
+++ b/DEHEASysML/DstController/IDstController.cs
@@ -136,6 +136,11 @@ namespace DEHEASysML.DstController
         List<BinaryRelationship> MappedConnectorsToBinaryRelationships { get; }
 
         /// <summary>
+        /// Gets the correspondence between an <see cref="IDualElement.ElementGUID"/> and the mapped <see cref="IDualElement.StereotypeEx"/>
+        /// </summary>
+        Dictionary<string, string> UpdatedStereotypes { get; }
+
+        /// <summary>
         /// Handle to clear everything when Enterprise Architect close
         /// </summary>
         void Disconnect();

--- a/DEHEASysML/Extensions/StereotypeExtensions.cs
+++ b/DEHEASysML/Extensions/StereotypeExtensions.cs
@@ -33,6 +33,8 @@ namespace DEHEASysML.Extensions
 
     using EA;
 
+    using CustomProperty = EA.CustomProperty;
+
     /// <summary>
     /// The <see cref="StereotypeExtensions" /> provides useful methods to verify stereotypes used in EA
     /// </summary>
@@ -155,7 +157,7 @@ namespace DEHEASysML.Extensions
         /// <returns>A collection of <see cref="Element"/></returns>
         public static IEnumerable<Element> GetAllPortsDefinitionOfElement(this Element element)
         {
-            return element.Elements.OfType<Element>().Where(x => x.Stereotype.AreEquals(StereotypeKind.Block));
+            return element.Elements.OfType<Element>().Where(x => x.HasStereotype(StereotypeKind.Block));
         }
 
         /// <summary>
@@ -262,7 +264,7 @@ namespace DEHEASysML.Extensions
         /// <returns>A collection of <see cref="Element"/></returns>
         public static IEnumerable<Element> GetElementsOfStereotypeInPackage(this IDualPackage package, StereotypeKind stereotype)
         {
-            return package.Elements.OfType<Element>().Where(x => x.Stereotype.AreEquals(stereotype));
+            return package.Elements.OfType<Element>().Where(x => x.HasStereotype(stereotype));
         }
 
         /// <summary>
@@ -274,6 +276,17 @@ namespace DEHEASysML.Extensions
         public static IEnumerable<Element> GetElementsOfTypeInPackage(this IDualPackage package, StereotypeKind stereotype)
         {
             return package.Elements.OfType<Element>().Where(x => x.MetaType.AreEquals(stereotype));
+        }
+
+        /// <summary>
+        /// Asserts if the <see cref="Element"/> has the <see cref="StereotypeKind"/> applied
+        /// </summary>
+        /// <param name="element">The <see cref="Element"/></param>
+        /// <param name="stereotype">The <see cref="StereotypeKind"/></param>
+        /// <returns>A value indicating if the <see cref="StereotypeKind"/> is applied</returns>
+        public static bool HasStereotype(this Element element, StereotypeKind stereotype)
+        {
+            return element.HasStereotype(stereotype.GetStereotypeName());
         }
 
         /// <summary>
@@ -297,6 +310,23 @@ namespace DEHEASysML.Extensions
                 case StereotypeKind.ProvidedInterface:
                 case StereotypeKind.State:
                     return string.Empty;
+                default: return stereotype.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Get the name of the provided <see cref="StereotypeKind"/>
+        /// </summary>
+        /// <param name="stereotype">The <see cref="StereotypeKind"/></param>
+        /// <returns>The stereotype name</returns>
+        public static string GetStereotypeName(this StereotypeKind stereotype)
+        {
+            switch (stereotype)
+            {
+                case StereotypeKind.Unit:
+                case StereotypeKind.Block:
+                case StereotypeKind.Requirement:
+                    return stereotype.ToString().ToLower();
                 default: return stereotype.ToString();
             }
         }

--- a/DEHEASysML/MappingRules/BlockDefinitionToElementDefinitionMappingRule.cs
+++ b/DEHEASysML/MappingRules/BlockDefinitionToElementDefinitionMappingRule.cs
@@ -346,6 +346,7 @@ namespace DEHEASysML.MappingRules
             this.MapCategory(elementDefinition, this.isAbstractCategoryNames, element.Abstract == "1", true);
             this.MapCategory(elementDefinition, this.isActiveCategoryNames, element.IsActive, false);
             this.MapCategory(elementDefinition, this.isEncapsulatedCategoryNames, isEncapsulated, true);
+            this.MapStereotypesToCategory(element, elementDefinition);
         }
 
         /// <summary>

--- a/DEHEASysML/MappingRules/DstToHubBaseMappingRule.cs
+++ b/DEHEASysML/MappingRules/DstToHubBaseMappingRule.cs
@@ -26,13 +26,18 @@ namespace DEHEASysML.MappingRules
 {
     using System;
     using System.Collections.Generic;
-    using System.Threading.Tasks;
 
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
 
     using CDP4Dal.Operations;
+
+    using DEHEASysML.Extensions;
+
+    using EA;
+
+    using Task = System.Threading.Tasks.Task;
 
     /// <summary>
     /// The <see cref="DstToHubBaseMappingRule{TInput,TOuput}" /> provides some methods common for all
@@ -147,6 +152,26 @@ namespace DEHEASysML.MappingRules
             }
 
             return relationship;
+        }
+
+        /// <summary>
+        /// Maps all Stereotypes applied to the <see cref="Element"/> to <see cref="Category"/> and adds all <see cref="Category"/>
+        /// to the <see cref="ICategorizableThing"/>
+        /// </summary>
+        /// <param name="element">The <see cref="Element"/></param>
+        /// <param name="thing">The <see cref="ICategorizableThing"/></param>
+        protected void MapStereotypesToCategory(Element element, ICategorizableThing thing)
+        {
+            foreach (var stereotype in element.GetStereotypeList().Split(','))
+            {
+                if (this.HubController.TryGetThingBy(x => string.Equals(x.Name, stereotype, StringComparison.InvariantCultureIgnoreCase)
+                                                          && !x.IsDeprecated, ClassKind.Category, out Category category)
+                    || this.TryCreateCategory((stereotype.GetShortName(), stereotype), out category, ((Thing)thing).ClassKind))
+                {
+                    thing.Category.RemoveAll(x => x.Iid == category.Iid);
+                    thing.Category.Add(category);
+                }
+            }
         }
     }
 }

--- a/DEHEASysML/MappingRules/ElementDefinitionToBlockMappingRule.cs
+++ b/DEHEASysML/MappingRules/ElementDefinitionToBlockMappingRule.cs
@@ -125,6 +125,7 @@ namespace DEHEASysML.MappingRules
                     foreach (var mappedElement in this.Elements.ToList())
                     {
                         this.MapPorts(mappedElement);
+                        this.MapCategoriesToStereotype(mappedElement.DstElement, mappedElement.HubElement);
                     }
 
                     foreach (var portToLink in this.portsToLink)
@@ -681,7 +682,7 @@ namespace DEHEASysML.MappingRules
             if (!this.DstController.TryGetElement(elementBaseName, StereotypeKind.Block, out element))
             {
                 var package = this.DstController.GetDefaultPackage(StereotypeKind.Block);
-                element = this.DstController.AddNewElement(package.Elements, elementBaseName, StereotypeKind.Block.ToString().ToLower(), StereotypeKind.Block);
+                element = this.DstController.AddNewElement(package.Elements, elementBaseName, StereotypeKind.Block.GetStereotypeName(), StereotypeKind.Block);
                 return false;
             }
 

--- a/DEHEASysML/MappingRules/HubRequirementToDstRequirementMappingRule.cs
+++ b/DEHEASysML/MappingRules/HubRequirementToDstRequirementMappingRule.cs
@@ -108,6 +108,7 @@ namespace DEHEASysML.MappingRules
                     foreach (var requirementMappedElement in this.Elements)
                     {
                         this.LinkRequirements(requirementMappedElement);
+                        this.MapCategoriesToStereotype(requirementMappedElement.DstElement, requirementMappedElement.HubElement);
                     }
 
                     this.SaveMappingConfiguration(new List<MappedElementRowViewModel<Requirement>>(this.Elements));

--- a/DEHEASysML/Services/MappingConfiguration/MappingConfigurationService.cs
+++ b/DEHEASysML/Services/MappingConfiguration/MappingConfigurationService.cs
@@ -284,7 +284,7 @@ namespace DEHEASysML.Services.MappingConfiguration
                     continue;
                 }
 
-                if (element.Stereotype.AreEquals(StereotypeKind.Block))
+                if (element.HasStereotype(StereotypeKind.Block))
                 {
                     if (!this.hubController.GetThingById(idCorrespondences.First().InternalId, this.hubController.OpenIteration,
                             out ElementDefinition elementDefinition))
@@ -294,7 +294,7 @@ namespace DEHEASysML.Services.MappingConfiguration
 
                     mappedElements.Add(new EnterpriseArchitectBlockElement(elementDefinition.Clone(true), element, MappingDirection.FromDstToHub));
                 }
-                else if (element.Stereotype.AreEquals(StereotypeKind.Requirement))
+                else if (element.HasStereotype(StereotypeKind.Requirement))
                 {
                     if (!this.hubController.GetThingById(idCorrespondences.First().InternalId, this.hubController.OpenIteration,
                             out Requirement requirement))
@@ -330,7 +330,7 @@ namespace DEHEASysML.Services.MappingConfiguration
                     continue;
                 }
 
-                if (element.Stereotype.AreEquals(StereotypeKind.Block))
+                if (element.HasStereotype(StereotypeKind.Block))
                 {
                     if (!this.hubController.GetThingById(idCorrespondences.First().InternalId, this.hubController.OpenIteration,
                             out ElementDefinition elementDefinition))
@@ -357,7 +357,7 @@ namespace DEHEASysML.Services.MappingConfiguration
                         }
                     }
                 }
-                else if (element.Stereotype.AreEquals(StereotypeKind.Requirement))
+                else if (element.HasStereotype(StereotypeKind.Requirement))
                 {
                     if (!this.hubController.GetThingById(idCorrespondences.First().InternalId, this.hubController.OpenIteration,
                             out Requirement requirement))

--- a/DEHEASysML/ViewModel/Dialogs/DstMappingConfigurationDialogViewModel.cs
+++ b/DEHEASysML/ViewModel/Dialogs/DstMappingConfigurationDialogViewModel.cs
@@ -131,13 +131,13 @@ namespace DEHEASysML.ViewModel.Dialogs
             var newElementsToMap = this.elements.Where(x => this.MappedElements
                                                                 .OfType<EnterpriseArchitectRequirementElement>()
                                                                 .All(mapped => mapped.DstElement.ElementGUID != x.ElementGUID) &&
-                                                            x.Stereotype.AreEquals(StereotypeKind.Requirement))
+                                                            x.HasStereotype(StereotypeKind.Requirement))
                 .Select(requirement => new EnterpriseArchitectRequirementElement(null, requirement, MappingDirection.FromDstToHub))
                 .Cast<IMappedElementRowViewModel>().ToList();
 
             newElementsToMap.AddRange(this.elements.Where(x => this.MappedElements
                     .OfType<EnterpriseArchitectBlockElement>()
-                    .All(mapped => mapped.DstElement.ElementGUID != x.ElementGUID) && x.Stereotype.AreEquals(StereotypeKind.Block))
+                    .All(mapped => mapped.DstElement.ElementGUID != x.ElementGUID) && x.HasStereotype(StereotypeKind.Block))
                 .Select(block => new EnterpriseArchitectBlockElement(null, block, MappingDirection.FromDstToHub))
                 .Cast<IMappedElementRowViewModel>().ToList());
 
@@ -295,12 +295,12 @@ namespace DEHEASysML.ViewModel.Dialogs
         /// <param name="element">The <see cref="Element" /></param>
         private void SetDstSelectedThing(Element element)
         {
-            if (element.Stereotype.AreEquals(StereotypeKind.Requirement))
+            if (element.HasStereotype(StereotypeKind.Requirement))
             {
                 this.SelectedItem = this.MappedElements.OfType<EnterpriseArchitectRequirementElement>()
                     .FirstOrDefault(x => x.DstElement.ElementGUID == element.ElementGUID);
             }
-            else if (element.Stereotype.AreEquals(StereotypeKind.Block))
+            else if (element.HasStereotype(StereotypeKind.Block))
             {
                 this.SelectedItem = this.MappedElements.OfType<EnterpriseArchitectBlockElement>()
                     .FirstOrDefault(x => x.DstElement.ElementGUID == element.ElementGUID);

--- a/DEHEASysML/ViewModel/Dialogs/HubMappingConfigurationDialogViewModel.cs
+++ b/DEHEASysML/ViewModel/Dialogs/HubMappingConfigurationDialogViewModel.cs
@@ -239,8 +239,8 @@ namespace DEHEASysML.ViewModel.Dialogs
                 return;
             }
 
-            this.CanExecuteMapToNewElement = this.SelectedElement.Stereotype.AreEquals(StereotypeKind.Requirement) && this.SelectedItem is RequirementMappedElement ||
-                                             this.SelectedElement.Stereotype.AreEquals(StereotypeKind.Block) && this.SelectedItem is ElementDefinitionMappedElement;
+            this.CanExecuteMapToNewElement = this.SelectedElement.HasStereotype(StereotypeKind.Requirement) && this.SelectedItem is RequirementMappedElement ||
+                                             this.SelectedElement.HasStereotype(StereotypeKind.Block) && this.SelectedItem is ElementDefinitionMappedElement;
         }
 
         /// <summary>

--- a/DEHEASysML/ViewModel/EnterpriseArchitectObjectBrowser/Rows/EnterpriseArchitectObjectRowViewModel.cs
+++ b/DEHEASysML/ViewModel/EnterpriseArchitectObjectBrowser/Rows/EnterpriseArchitectObjectRowViewModel.cs
@@ -111,7 +111,7 @@ namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows
                     break;
                 case Element element:
                     this.Name = element.Name;
-                    this.RowType = element.Stereotype;
+                    this.RowType = element.StereotypeEx;
                     break;
                 case Partition partition:
                     this.Name = partition.Name;

--- a/DEHEASysML/ViewModel/EnterpriseArchitectObjectBrowser/Rows/PackageRowViewModel.cs
+++ b/DEHEASysML/ViewModel/EnterpriseArchitectObjectBrowser/Rows/PackageRowViewModel.cs
@@ -118,7 +118,7 @@ namespace DEHEASysML.ViewModel.EnterpriseArchitectObjectBrowser.Rows
 
             ElementRowViewModel row;
 
-            if (element.Stereotype.AreEquals(StereotypeKind.Requirement))
+            if (element.HasStereotype(StereotypeKind.Requirement))
             {
                 row = new ElementRequirementRowViewModel(this, element);
             }

--- a/DEHEASysML/ViewModel/NetChangePreview/DstNetChangePreviewViewModel.cs
+++ b/DEHEASysML/ViewModel/NetChangePreview/DstNetChangePreviewViewModel.cs
@@ -243,6 +243,11 @@ namespace DEHEASysML.ViewModel.NetChangePreview
 
                 var row = this.GetOrCreateRow(mappedElement);
 
+                if (this.dstController.UpdatedStereotypes.ContainsKey(mappedElement.ElementGUID))
+                {
+                    row.RowType = this.dstController.UpdatedStereotypes[mappedElement.ElementGUID];
+                }
+
                 this.HighlightRowAndParentRow(row);
 
                 foreach (var valuePropertyRow in row.ContainedRows.OfType<ValuePropertyRowViewModel>())
@@ -360,8 +365,8 @@ namespace DEHEASysML.ViewModel.NetChangePreview
 
             var element = this.dstController.CurrentRepository.GetElementByID(elementId);
 
-            if (element.Stereotype.AreEquals(StereotypeKind.Block) || element.Stereotype.AreEquals(StereotypeKind.Requirement)
-                                                                   || element.Stereotype.AreEquals(StereotypeKind.State))
+            if (element.HasStereotype(StereotypeKind.Block) || element.HasStereotype(StereotypeKind.Requirement)
+                                                            || element.Stereotype.AreEquals(StereotypeKind.State))
             {
                 var row = this.GetOrCreateRow(element);
 

--- a/DEHEASysML/ViewModel/NetChangePreview/HubObjectNetChangePreviewViewModel.cs
+++ b/DEHEASysML/ViewModel/NetChangePreview/HubObjectNetChangePreviewViewModel.cs
@@ -366,14 +366,21 @@ namespace DEHEASysML.ViewModel.NetChangePreview
         /// <param name="isSelected">A value indicating wheter to select the element for transfer</param>
         private void AddOrRemoveToSelectedThingsToTransfer(ElementDefinition elementDefinition, bool isSelected)
         {
-            foreach (var parameter in elementDefinition.Parameter)
+            if (elementDefinition.ContainedElement.Count == 0 && elementDefinition.Parameter.Count == 0)
             {
-                this.AddOrRemoveToSelectedThingsToTransfer(parameter, isSelected);
+                this.AddOrRemoveToSelectedThingsToTransfer((Thing)elementDefinition, isSelected);
             }
-
-            foreach (var elementUsage in elementDefinition.ContainedElement)
+            else
             {
-                this.AddOrRemoveToSelectedThingsToTransfer(elementUsage, isSelected);
+                foreach (var parameter in elementDefinition.Parameter)
+                {
+                    this.AddOrRemoveToSelectedThingsToTransfer(parameter, isSelected);
+                }
+
+                foreach (var elementUsage in elementDefinition.ContainedElement)
+                {
+                    this.AddOrRemoveToSelectedThingsToTransfer(elementUsage, isSelected);
+                }
             }
         }
 

--- a/DEHEASysML/ViewModel/Rows/MappingRowViewModel.cs
+++ b/DEHEASysML/ViewModel/Rows/MappingRowViewModel.cs
@@ -181,7 +181,7 @@ namespace DEHEASysML.ViewModel.Rows
         /// <param name="dstElement">The <see cref="Element" /> to represents</param>
         private void InitializeDstThing(Element dstElement)
         {
-            if (dstElement.Stereotype.AreEquals(StereotypeKind.Block))
+            if (dstElement.HasStereotype(StereotypeKind.Block))
             {
                 foreach (var valueProperty in dstElement.GetAllValuePropertiesOfElement()
                              .Where(x => this.dstController.CreatedElements.All(created => created.ElementGUID != x.ElementGUID)))
@@ -209,7 +209,7 @@ namespace DEHEASysML.ViewModel.Rows
                     this.DstThing.First().ContainedRows.Add(new MappedThing(valueProperty.Name, value));
                 }
             }
-            else if (dstElement.Stereotype.AreEquals(StereotypeKind.Requirement))
+            else if (dstElement.HasStereotype(StereotypeKind.Requirement))
             {
                 this.DstThing.First().ContainedRows.Add(new MappedThing("Id", dstElement.GetRequirementId()));
                 this.DstThing.First().ContainedRows.Add(new MappedThing("Text", dstElement.GetRequirementText()));


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEH-EASYSML/pulls) open
- [x] I have verified that I am following the DEH-EASYSML [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEH-EASYSML/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #54 

- If a stereotype inherits from 'block' or 'requirement', the element on which the stereotype is applied can be map 
- Each applied stereotype is mapped to a 10-25 Category
- Each assigned Category will be translated has a Stereotype
- When applying the Stereotype from hub to dst, if any of the applied ones are detected as 'block' or 'requirement', the previous Stereotype is reapplied
- If no Category is present on the hub, default Stereotype is applied 
<!-- Thanks for contributing to DEH-EASYSML! -->