### PR TITLE
ActualFiniteState cannot be null anymore ; Fix #63

### DIFF
--- a/DEHEASysML/MappingRules/ElementDefinitionToBlockMappingRule.cs
+++ b/DEHEASysML/MappingRules/ElementDefinitionToBlockMappingRule.cs
@@ -485,7 +485,9 @@ namespace DEHEASysML.MappingRules
                 this.MappingConfiguration.AddToExternalIdentifierMap(parameter.Iid, parameterRow.SelectedActualFiniteState.Iid.ToString(), MappingDirection.FromHubToDst);
             }
 
-            var valueToAssign = parameter.QueryParameterBaseValueSet(null, parameterRow.SelectedActualFiniteState).ActualValue[0];
+            var option = parameter.IsOptionDependent ? parameter.GetContainerOfType<Iteration>().Option.First() : null;
+
+            var valueToAssign = parameter.QueryParameterBaseValueSet(option, parameterRow.SelectedActualFiniteState).ActualValue[0];
 
             if (valueToAssign == "-")
             {

--- a/DEHEASysML/MappingRules/RequirementElementToRequirementMappingRule.cs
+++ b/DEHEASysML/MappingRules/RequirementElementToRequirementMappingRule.cs
@@ -80,13 +80,6 @@ namespace DEHEASysML.MappingRules
         private List<EnterpriseArchitectRequirementElement> mappedElements;
 
         /// <summary>
-        /// The <see cref="Category" /> to apply to each <see cref="CDP4Common.EngineeringModelData.Requirement" />,
-        /// <see cref="RequirementsGroup" /> and
-        /// <see cref="RequirementsSpecification" />
-        /// </summary>
-        private Category requirementRelationshipCategory;
-
-        /// <summary>
         /// Transform a <see cref="List{T}" /> of <see cref="EnterpriseArchitectRequirementElement" /> into a
         /// <see cref="List{T}" /> of
         /// <see cref="MappedRequirementRowViewModel" />
@@ -109,15 +102,6 @@ namespace DEHEASysML.MappingRules
                 this.MappingConfiguration = AppContainer.Container.Resolve<IMappingConfigurationService>();
                 this.DstController = AppContainer.Container.Resolve<IDstController>();
                 var (completeMapping, elements) = input;
-
-                this.HubController.TryGetThingBy(x => x.ShortName == this.requirementRelationshipCategoryNames.shortname
-                                                      && !x.IsDeprecated, ClassKind.Category, out this.requirementRelationshipCategory);
-
-                if (this.requirementRelationshipCategory == null)
-                {
-                    this.TryCreateCategory(this.requirementRelationshipCategoryNames, out this.requirementRelationshipCategory, ClassKind.Requirement,
-                        ClassKind.RequirementsGroup, ClassKind.RequirementsSpecification);
-                }
 
                 this.requirementsSpecifications.Clear();
                 this.requirementsGroups.Clear();

--- a/DEHEASysML/Services/MappingConfiguration/MappingConfigurationService.cs
+++ b/DEHEASysML/Services/MappingConfiguration/MappingConfigurationService.cs
@@ -338,21 +338,30 @@ namespace DEHEASysML.Services.MappingConfiguration
                         continue;
                     }
 
-                    var elementDefinitionMappedElement = new ElementDefinitionMappedElement(elementDefinition.Clone(true), element, MappingDirection.FromHubToDst);
+                    var elementDefinitionMappedElement = new ElementDefinitionMappedElement(elementDefinition.Clone(true), element,
+                        MappingDirection.FromHubToDst);
+
                     mappedElements.Add(elementDefinitionMappedElement);
 
-                    foreach (var parameterIid in elementDefinition.Parameter.Select(x =>x.Iid))
+                    foreach (var parameter in elementDefinition.Parameter.Where(x => x.StateDependence != null))
                     {
-                        if (this.correspondences.FirstOrDefault(x => x.InternalId == parameterIid).ExternalIdentifier
+                        var parameterRow = elementDefinitionMappedElement.ContainedRows.OfType<MappedParameterRowViewModel>()
+                            .FirstOrDefault(x => x.HubElement.Iid == parameter.Iid);
+
+                        if (this.correspondences.FirstOrDefault(x => x.InternalId == parameter.Iid).ExternalIdentifier
                                 is { } external && this.hubController.GetThingById(new Guid(external.Identifier), 
                                 this.hubController.OpenIteration, out ActualFiniteState actualFiniteState))
                         {
-                            var parameterRow = elementDefinitionMappedElement.ContainedRows.OfType<MappedParameterRowViewModel>()
-                                .FirstOrDefault(x => x.HubElement.Iid == parameterIid);
-
                             if (parameterRow != null)
                             {
                                 parameterRow.SelectedActualFiniteState = actualFiniteState;
+                            }
+                        }
+                        else
+                        {
+                            if (parameterRow != null)
+                            {
+                                parameterRow.SelectedActualFiniteState = parameter.StateDependence.ActualState[0];
                             }
                         }
                     }

--- a/DEHEASysML/ViewModel/Dialogs/HubMappingConfigurationDialogViewModel.cs
+++ b/DEHEASysML/ViewModel/Dialogs/HubMappingConfigurationDialogViewModel.cs
@@ -128,6 +128,11 @@ namespace DEHEASysML.ViewModel.Dialogs
 
             this.EnterpriseArchitectObjectBrowser.BuildTree(this.DstController.CurrentRepository.Models.OfType<Package>(), allElements, packageIds);
 
+            foreach (var elementDefinition in this.things.OfType<ElementDefinition>().ToList())
+            {
+                this.AddElementUsageWithStateDependence(elementDefinition);
+            }
+
             this.PreMap();
         }
 
@@ -166,6 +171,23 @@ namespace DEHEASysML.ViewModel.Dialogs
 
             this.MappedElements.AddRange(newMappingCollection);
             this.IsBusy = false;
+        }
+
+        /// <summary>
+        /// Adds all <see cref="ElementDefinition"/> of <see cref="ElementUsage"/> that has a <see cref="ActualFiniteState"/> dependency
+        /// </summary>
+        /// <param name="elementDefinition">An <see cref="ElementDefinition"/> to look through</param>
+        private void AddElementUsageWithStateDependence(ElementDefinition elementDefinition)
+        {
+            if(this.things.All(x => x.Iid != elementDefinition.Iid) && elementDefinition.Parameter.Any(x => x.StateDependence != null))
+            {
+                this.things.Add(elementDefinition);
+            }
+
+            foreach (var elementUsage in elementDefinition.ContainedElement)
+            {
+                this.AddElementUsageWithStateDependence(elementUsage.ElementDefinition);
+            }
         }
 
         /// <summary>

--- a/DEHEASysML/ViewModel/Rows/MappedParameterRowViewModel.cs
+++ b/DEHEASysML/ViewModel/Rows/MappedParameterRowViewModel.cs
@@ -70,7 +70,13 @@ namespace DEHEASysML.ViewModel.Rows
         public ActualFiniteState SelectedActualFiniteState
         {
             get => this.selectedActualFiniteState;
-            set => this.RaiseAndSetIfChanged(ref this.selectedActualFiniteState, value);
+            set
+            {
+                if (value != null)
+                {
+                    this.RaiseAndSetIfChanged(ref this.selectedActualFiniteState, value);
+                }
+            } 
         }
 
         /// <summary>

--- a/DEHEASysML/Views/Dialogs/HubMappingConfigurationDialog.xaml
+++ b/DEHEASysML/Views/Dialogs/HubMappingConfigurationDialog.xaml
@@ -176,7 +176,7 @@
                                     </Grid.ColumnDefinitions>
                                     <TextBlock Grid.Column="0" Text="{Binding Row.SourceElementName}" VerticalAlignment="Center"
                                                FontSize="12" Margin="2 0 0 0"/>
-                                    <dxe:ComboBoxEdit Grid.Column="1" Width="150"  
+                                    <dxe:ComboBoxEdit Grid.Column="1" Width="150"  AllowUpdateTwoWayBoundPropertiesOnSynchronization="True"
                                                       ItemsSource="{Binding Row.AvailableActualFiniteStates}"
                                                       SelectedItem="{Binding Row.SelectedActualFiniteState, Mode=TwoWay}"
                                                       AllowNullInput="False" DisplayMember="Name"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEH-EASYSML/pulls) open
- [x] I have verified that I am following the DEH-EASYSML [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEH-EASYSML/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #63 

- ActualFiniteState cannot be null anymore at anytime
- HubMappingConfigurationDialog is not able to set the selected ActualFiniteState anymore

<!-- Thanks for contributing to DEH-EASYSML! -->